### PR TITLE
Rename to opayo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 composer.lock
 composer.phar
 phpunit.xml
+.phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Omnipay: Sage Pay
+# Omnipay: Opayo
 
-**Sage Pay driver for the Omnipay PHP payment processing library**
+**Opayo driver for the Omnipay PHP payment processing library**
 
 [![Build Status](https://travis-ci.org/thephpleague/omnipay-sagepay.png?branch=master)](https://travis-ci.org/thephpleague/omnipay-sagepay)
 [![Latest Stable Version](https://poser.pugx.org/omnipay/sagepay/version.png)](https://packagist.org/packages/omnipay/sagepay)
@@ -8,8 +8,8 @@
 
 [Omnipay](https://github.com/thephpleague/omnipay) is a framework agnostic,
 multi-gateway payment processing library for PHP.
-This package implements Sage Pay support for Omnipay.
-This version supports PHP ^5.6 and PHP ^7.
+This package implements Opayo (formerly known as Sage Pay) support for Omnipay.
+This version supports PHP ^7.2 and PHP ^8.
 
 This is the `master` branch of Omnipay, handling Omnipay version `3.x`.
 For the `2.x` branch, please visit https://github.com/thephpleague/omnipay-sagepay/tree/2.x
@@ -19,25 +19,25 @@ Table of Contents
 
 <!-- TOC -->
 
-- [Omnipay: Sage Pay](#omnipay-sage-pay)
+- [Omnipay: Opayo](#omnipay-opayo)
 - [Installation](#installation)
 - [Basic Usage](#basic-usage)
 - [Supported Methods](#supported-methods)
-    - [Sage Pay Direct Methods](#sage-pay-direct-methods)
+    - [Opayo Pay Direct Methods](#opayo-direct-methods)
         - [Direct Authorize/Purchase](#direct-authorizepurchase)
             - [Redirect (3D Secure)](#redirect-3d-secure)
             - [Redirect Return](#redirect-return)
         - [Direct Create Card](#direct-create-card)
-    - [Sage Pay Server Methods](#sage-pay-server-methods)
+    - [Opayo Server Methods](#opayo-server-methods)
         - [Server Gateway](#server-gateway)
         - [Server Authorize/Purchase](#server-authorizepurchase)
         - [Server Create Card](#server-create-card)
         - [Server Notification Handler](#server-notification-handler)
-    - [Sage Pay Form Methods](#sage-pay-form-methods)
+    - [Opayo Form Methods](#opayo-form-methods)
         - [Form Authorize](#form-authorize)
         - [Form completeAuthorize](#form-completeauthorize)
         - [Form Purchase](#form-purchase)
-    - [Sage Pay Shared Methods (Direct and Server)](#sage-pay-shared-methods-direct-and-server)
+    - [Opayo Shared Methods (Direct and Server)](#opayo-shared-methods-direct-and-server)
         - [Repeat Authorize/Purchase](#repeat-authorizepurchase)
         - [Capture](#capture)
         - [Delete Card](#delete-card)
@@ -61,7 +61,7 @@ To install, simply add it to your `composer.json` file:
 ```json
 {
     "require": {
-        "omnipay/sagepay": "~3.0"
+        "omnipay/opayo": "~3.0"
     }
 }
 ```
@@ -75,18 +75,18 @@ And run composer to update your dependencies:
 
 The following gateways are provided by this package:
 
-* SagePay_Direct
-* SagePay_Server
-* SagePay_Form
+* Opayo_Direct
+* Opayo_Server
+* Opayo_Form
 
 For general Omnipay usage instructions, please see the main
 [Omnipay](https://github.com/thephpleague/omnipay) repository.
 
 # Supported Methods
 
-## Sage Pay Direct Methods
+## Opayo Direct Methods
 
-Sage Pay Direct is a server-to-server protocol, with all credit card details
+Opayo Direct is a server-to-server protocol, with all credit card details
 needing to pass through your application for forwarding on to the gateway.
 You must be aware of the PCI implications of handling credit card details
 if using this API.
@@ -107,7 +107,7 @@ use Omnipay\Common\CreditCard;
 
 // Create the gateway object.
 
-$gateway = OmniPay::create('SagePay\Direct')->initialize([
+$gateway = OmniPay::create('Opayo\Direct')->initialize([
     'vendor' => 'vendorname',
     'testMode' => true,
 ]);
@@ -139,7 +139,7 @@ $requestMessage = $gateway->purchase([
     // If 3D Secure is enabled, then provide a return URL for
     // when the user comes back from 3D Secure authentication.
 
-    'returnUrl' => 'https://example.co.uk/sagepay-complete',
+    'returnUrl' => 'https://example.co.uk/opayo-complete',
 ]);
 
 // Send the request message.
@@ -198,13 +198,13 @@ If you want to authorize an amount on the card *and* get a cardReference
 for repeated use of the card, then use the `authorize()` method with the
 `createToken` flag set.
 
-Sample code using Sage Pay Direct to create a card reference:
+Sample code using Opayo Direct to create a card reference:
 
 ```php
 use Omnipay\Omnipay;
 use Omnipay\CreditCard;
 
-$gateway = OmniPay::create('SagePay\Direct');
+$gateway = OmniPay::create('Opayo\Direct');
 
 $gateway->setVendor('your-vendor-code');
 $gateway->setTestMode(true); // For test account
@@ -243,13 +243,13 @@ if ($response->isSuccessful()) {
 }
 ```
 
-## Sage Pay Server Methods
+## Opayo Server Methods
 
-Sage Pay Server captures any credit card details in forms hosted by the
-Sage Pay gateway, either by sending the user to the gateway or loading the
+Opayo Server captures any credit card details in forms hosted by the
+Opayo gateway, either by sending the user to the gateway or loading the
 hosted forms in an iframe. This is the preferred and safest API to use.
 
-Sage Pay Server uses your IP address to authenticate backend access to the
+Opayo Server uses your IP address to authenticate backend access to the
 gateway, and it also needs to a public URL that it can send back-channel
 notifications to. This makes development on a localhost server difficult.
 
@@ -261,7 +261,7 @@ notifications to. This makes development on a localhost server difficult.
 
 ### Server Gateway
 
-All Sage Pay Server methods start by creating the gateway object, which we
+All Opayo Server methods start by creating the gateway object, which we
 will store in `$gateway` here. Note there are no secrets or passwords that need
 to be set, as the gateway uses your server's IP address as its main method of
 authenticating your application.
@@ -271,7 +271,7 @@ The gateway object is minimally created like this:
 ```php
 use Omnipay\Omnipay;
 
-$gateway = OmniPay::create('SagePay\Server');
+$gateway = OmniPay::create('Opayo\Server');
 
 $gateway->setVendor('your-vendor-code');
 $gateway->setTestMode(true); // For a test account
@@ -395,7 +395,7 @@ if ($response->isSuccessful()) {
     // If a cardReference was provided, then only the CVV will be asked for.
     // 3D Secure will be performed here too, if enabled.
     // Once the user is redirected to the gateway, the results will be POSTed
-    // to the [notification handler](#sage-pay-server-notification-handler).
+    // to the [notification handler](#opayo-server-notification-handler).
     // The handler will then inform the gateway where to finally return the user
     // to on the merchant site.
 
@@ -404,17 +404,17 @@ if ($response->isSuccessful()) {
     // Something went wrong; get the message.
     // The error may be a simple validation error on the address details.
     // Catch those and allow the user to correct the details and submit again.
-    // This is a particular pain point of Sage Pay Server.
+    // This is a particular pain point of Opayo Server.
     $reason = $response->getMessage();
 }
 ```
 
 ### Server Create Card
 
-When creating a cardReference, for Sage Pay Server the reference will be available
+When creating a cardReference, for Opayo Server the reference will be available
 only in the notification callback.
 
-Sample code using Sage Pay Server to create a card reference:
+Sample code using Opayo Server to create a card reference:
 
 ```php
 // The transaction ID is used to store the result in the notify callback.
@@ -431,7 +431,7 @@ $request = $gateway->createCard([
 $response = $request->send();
 
 if ($response->isSuccessful()) {
-    // Should never happen for Sage Pay Server, since the user will always
+    // Should never happen for Opayo Server, since the user will always
     // be asked to go off-site to enter their credit card details.
 } elseif ($response->isRedirect()) {
     // Redirect to offsite payment gateway to capture the users credit card
@@ -460,12 +460,12 @@ to break out of the iframe.
 
 ### Server Notification Handler
 
-> **NOTE:** The notification handler was previously handled by the SagePay_Server `completeAuthorize`,
+> **NOTE:** The notification handler was previously handled by the Opayo_Server `completeAuthorize`,
   `completePurchase` and `completeRegistration` methods.
   The notification handler replaces all of these.
 
-The `SagePay_Server` gateway uses a notification callback to receive the results of a payment or authorization.
-Sage Pay Direct does not use the notification handler.
+The `Opayo_Server` gateway uses a notification callback to receive the results of a payment or authorization.
+Opayo Direct does not use the notification handler.
 
 Unlike many newer gateways, this notification handler is not just an optional callback
 providing an additional channel for events.
@@ -474,8 +474,8 @@ It is *required* for the Server gateway, and not used for the direct gateway at 
 The URL for the notification handler is set in the authorize or payment message:
 
 ```php
-// The Server response will be a redirect to the Sage Pay CC form.
-// This is a Sage Pay Server Purchase request.
+// The Server response will be a redirect to the Opayo CC form.
+// This is a Opayo Server Purchase request.
 
 $transactionId = {create a unique transaction id};
 
@@ -504,7 +504,7 @@ $response = $gateway->purchase([
 // retrievable by `$transactionId`.
 
 if ($response->isRedirect()) {
-    // Go to Sage Pay to enter CC details.
+    // Go to Opayo to enter CC details.
     // While your user is there, the notification handler will be called
     // to accept the result and provide the final URL for the user.
 
@@ -517,17 +517,17 @@ Your notification handler needs to do four things:
 1. Look up the saved transaction in the database to retrieve the `securityKey`.
 2. Validate the signature of the received notification to protect against tampering.
 3. Update your saved transaction with the results.
-4. Respond to Sage Pay to indicate that you accept the result, reject the result or don't
+4. Respond to Opayo to indicate that you accept the result, reject the result or don't
    believe the notification was valid.
-   Also tell Sage Pay where to send the user next.
+   Also tell Opayo where to send the user next.
 
 This is a back-channel (server-to-server), so has no access to the end user's session.
 
 The acceptNotification gateway is set up simply.
-The `$request` will capture the POST data sent by Sage Pay:
+The `$request` will capture the POST data sent by Opayo:
 
 ```php
-$gateway = Omnipay\Omnipay::create('SagePay_Server');
+$gateway = Omnipay\Omnipay::create('Opayo_Server');
 $gateway->setVendor('your-vendor-name');
 $gateway->setTestMode(true); // To access your test account.
 $notifyRequest = $gateway->acceptNotification();
@@ -559,7 +559,7 @@ $notifyRequest->setSecurityKey($securityKey);
 $notifyRequest->setTransactionReference($transactionReference);
 
 if (! $notifyRequest->isValid()) {
-    // Respond to Sage Pay indicating we are not accepting anything about this message.
+    // Respond to Opayo indicating we are not accepting anything about this message.
     // You might want to log `$request->getData()` first, for later analysis.
 
     $notifyRequest->invalid($nextUrl, 'Signature not valid - goodbye');
@@ -575,12 +575,12 @@ $notifyRequest->error($nextUrl, 'This transaction does not exist on the system')
 ```
 
 > **Note:** it has been observed that the same notification message may be sent
-  by Sage Pay multiple times.
+  by Opayo multiple times.
   If this happens, then return the same response you sent the first time.
   So if you have confirmed a successful payment, then if you get another
   identical notification for the transaction, then return `confirm()` again.
 
-If you accept the notification, then you can update your local records and let Sage Pay know:
+If you accept the notification, then you can update your local records and let Opayo know:
 
 ```php
 // All raw data - just log it for later analysis:
@@ -610,12 +610,12 @@ if ($notifyRequest->getTxType() === $notifyRequest::TXTYPE_TOKEN) {
     $cardReference = $notifyRequest->getCardReference();
 }
 
-// Now let Sage Pay know you have accepted and saved the result:
+// Now let Opayo know you have accepted and saved the result:
 
 $notifyRequest->confirm($nextUrl);
 ```
 
-The `$nextUrl` is where you want Sage Pay to send the user to next.
+The `$nextUrl` is where you want Opayo to send the user to next.
 It will often be the same URL whether the transaction was approved or not,
 since the result will be safely saved in the database.
 
@@ -642,9 +642,9 @@ You must return it with a `200` HTTP Status Code:
 $bodyPayload = getResponseBody($status, $nextUrl, $detail = null);
 ```
 
-## Sage Pay Form Methods
+## Opayo Form Methods
 
-Sage Pay Form requires neither a server-to-server back-channel nor
+Opayo Form requires neither a server-to-server back-channel nor
 IP-based security.
 It does not require pre-registration of a transaction, so is ideal for
 a speculative "pay now" button on a page for instant purchases of a
@@ -658,7 +658,7 @@ The result is returned to the merchant site also through a client-side
 encrypted message.
 
 Capturing and voiding `Form` transactions is a manual process performed
-in the "My Sage Pay" administration panel.
+in the "My Opayo" administration panel.
 
 Supported functions are:
 
@@ -671,14 +671,14 @@ The authorization is intialized in a similar way to a `Server` payment,
 but with an `encryptionKey`:
 
 ```php
-$gateway = OmniPay::create('SagePay\Form')->initialize([
+$gateway = OmniPay::create('Opayo\Form')->initialize([
     'vendor' => 'vendorname',
     'testMode' => true,
     'encryptionKey' => 'abcdef1212345678',
 ]);
 ```
 
-The `encryptionKey` is generated in "My Sage Pay" when logged in as the administrator.
+The `encryptionKey` is generated in "My Opayo" when logged in as the administrator.
 
 Note that this gateway driver will assume all input data (names, addresses etc.)
 are UTF-8 encoded.
@@ -765,10 +765,10 @@ return a success status.
 This is the same as `authorize()`, but the `purchase()` request is used instead,
 and the `completePurchase()` request is used to complete the transaction on return.
 
-## Sage Pay Shared Methods (Direct and Server)
+## Opayo Shared Methods (Direct and Server)
 
 Note: these functions do not work for the `Form` API.
-These actions for `Sage Pay Form` must be performed manually through the "My Sage Pay"
+These actions for `Opayo Form` must be performed manually through the "My Opayo"
 admin panel.
 
 * `capture()`
@@ -882,9 +882,9 @@ This is one of the simpler messages:
 use Omnipay\Omnipay;
 use Omnipay\CreditCard;
 
-$gateway = OmniPay::create('SagePay\Direct');
+$gateway = OmniPay::create('Opayo\Direct');
 // or
-$gateway = OmniPay::create('SagePay\Server');
+$gateway = OmniPay::create('Opayo\Server');
 
 $gateway->setVendor('your-vendor-code');
 $gateway->setTestMode(true); // For test account
@@ -908,7 +908,7 @@ if ($response->isSuccessful()) {
 
 # Token Billing
 
-Sage Pay Server and Direct support the ability to store a credit card detail on
+Opayo Server and Direct support the ability to store a credit card detail on
 the gateway, referenced by a token, for later use or reuse.
 The token can be single-use, or permanently stored (until its expiry date or
 explicit removal).
@@ -928,13 +928,13 @@ as a part of a transaction:
 If created explicitly, then a CVV can be provided, and that will be stored against the token
 until the token is first used to make a payment. If the cardReference is reused after the first
 payment, then a CVV must be supplied each time (assuming your rules require the CVV to be present).
-If using Sage Pay Server, then the user will be prompted for a CVV on subsequent uses of
+If using Opayo Server, then the user will be prompted for a CVV on subsequent uses of
 the cardReference.
 
 If creating a `token` or `cardReference` with a transaction, then the CVV will never be
 stored against the token.
 
-The transaction response (or notification request for Sage Pay Server) will provide
+The transaction response (or notification request for Opayo Server) will provide
 the generated token. This is accessed using:
 
 * `$response->getToken()` or
@@ -945,8 +945,8 @@ are generated.
 
 ## Using a Token or CardReference
 
-To use a token with Sage Pay Direct, you must leave the credit card details blank in
-the `CreditCard` object. Sage Pay Server does not use the credit card details anyway.
+To use a token with Opayo Direct, you must leave the credit card details blank in
+the `CreditCard` object. Opayo Server does not use the credit card details anyway.
 To use the token as a single-use token, add it to the transaction request like this:
 
 `request->setToken($saved_token);`
@@ -965,15 +965,15 @@ or not, so can be used multiple times.
 
 # Basket format
 
-Sagepay currently supports two different formats for sending cart/item information to them:  
- - [BasketXML](http://www.sagepay.co.uk/support/12/36/protocol-3-00-basket-xml)
- - [Basket](http://www.sagepay.co.uk/support/error-codes/3021-invalid-basket-format-invalid)
+Opayo currently supports two different formats for sending cart/item information to them:
+ - [BasketXML](https://www.opayo.co.uk/support/12/36/protocol-3-00-basket-xml)
+ - [Basket](https://www.opayo.co.uk/support/error-codes/3021-invalid-basket-format-invalid)
 
 These are incompatible with each other, and cannot be both sent in the same transaction.
 *BasketXML* is the most recent format, and is the default used by this driver.
 *Basket* is an older format which may be deprecated one day,
 but is also the only format currently supported by some of the Sage accounting products
-(e.g. Line 50) which can pull transaction data directly from Sage Pay.
+(e.g. Line 50) which can pull transaction data directly from Opayo.
 For applications that require this type of integration, an optional parameter `useOldBasketFormat`
 with a value of `true` can be passed in the driver's `initialize()` method.
 
@@ -981,32 +981,32 @@ with a value of `true` can be passed in the driver's `initialize()` method.
 
 The Basket format can be used for Sage 50 Accounts Software Integration:
 
-> It is possible to integrate your Sage Pay account with Sage Accounting products to ensure you can
+> It is possible to integrate your Opayo account with Sage Accounting products to ensure you can
 > reconcile the transactions on your account within your financial software.
 > If you wish to link a transaction to a specific product record this can be done through the Basket field
   in the transaction registration post.
-> Please note the following integration is not currently available when using BasketXML fields. 
+> Please note the following integration is not currently available when using BasketXML fields.
 > In order for the download of transactions to affect a product record the first entry in a basket line needs
   to be the product code of the item within square brackets. For example:
-  
+
 ```
 4:[PR001]Pioneer NSDV99 DVD-Surround Sound System:1:424.68:74.32:499.00:499.00
 ```
 
-You can either prepend this onto the description or using `\Omnipay\SagePay\Extend\Item` you can use `setProductCode`
-which will take care of pre-pending `[]` for you. 
+You can either prepend this onto the description or using `\Omnipay\Opayo\Extend\Item` you can use `setProductCode`
+which will take care of pre-pending `[]` for you.
 
 # Account Types
 
-Your Sage Pay account will use separate merchant accounts for difference transaction sources.
+Your Opayo account will use separate merchant accounts for difference transaction sources.
 The sources are specified by the `accountType` parameter, and take one of three values:
 
-* "E" Omnipay\SagePay\Message\AbstractRequest::ACCOUNT_TYPE_E (default)  
+* "E" Omnipay\Opayo\Message\AbstractRequest::ACCOUNT_TYPE_E (default)
   For ecommerce transactions, entered in your application by the end user.
-* "M" Omnipay\SagePay\Message\AbstractRequest::ACCOUNT_TYPE_M  
+* "M" Omnipay\Opayo\Message\AbstractRequest::ACCOUNT_TYPE_M
   MOTO transactions taken by telephone or postal forms or faxes, entered by an operator.
   The operator may ask for a CVV when taking a telephone order.
-* "C" Omnipay\SagePay\Message\AbstractRequest::ACCOUNT_TYPE_C  
+* "C" Omnipay\Opayo\Message\AbstractRequest::ACCOUNT_TYPE_C
   For repeat transactions, generated by the merchant site without any human intervention.
 
 The "M" MOTO and "C" account types will also disable any 3D-Secure validation that may
@@ -1020,11 +1020,11 @@ there are some moves to do so.
 # VAT
 
 If you want to include VAT amount in the item array you must use
-`\Omnipay\SagePay\Extend\Item` as follows.
+`\Omnipay\Opayo\Extend\Item` as follows.
 
 ```php
 $items = [
-    [new \Omnipay\SagePay\Extend\Item([
+    [new \Omnipay\Opayo\Extend\Item([
         'name' => 'My Product Name',
         'description' => 'My Product Description',
         'quantity' => 1,
@@ -1044,9 +1044,9 @@ If you want to keep up to date with release announcements, discuss ideas for the
 or ask more detailed questions, there is also a [mailing list](https://groups.google.com/forum/#!forum/omnipay) which
 you can subscribe to.
 
-If you believe you have found a bug, please report it using the [GitHub issue tracker](https://github.com/thephpleague/omnipay-sagepay/issues),
+If you believe you have found a bug, please report it using the [GitHub issue tracker](https://github.com/thephpleague/omnipay-Opayo/issues),
 or better yet, fork the library and submit a pull request.
 
 #References
-- [Sage pay tokens using token management](https://www.opayo.co.uk/file/1171/download-document/sagepaytokensystemprotocolandintegrationguidelinev3.0_0.pdf)
-- [Other sage pay transaction types for Server method](https://developer-eu.elavon.com/docs/opayo-shared-api)
+- [Opayo tokens using token management](https://www.opayo.co.uk/file/1171/download-document/sagepaytokensystemprotocolandintegrationguidelinev3.0_0.pdf)
+- [Other Opayo transaction types for Server method](https://developer-eu.elavon.com/docs/opayo-shared-api)

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
-    "name": "omnipay/sagepay",
+    "name": "omnipay/opayo",
     "type": "library",
-    "description": "Sage Pay driver for the Omnipay PHP payment processing library",
+    "description": "Opayo driver for the Omnipay PHP payment processing library",
     "keywords": [
         "gateway",
         "merchant",
@@ -10,7 +10,8 @@
         "payment",
         "purchase",
         "sage pay",
-        "sagepay"
+        "sagepay",
+        "opayo"
     ],
     "homepage": "https://github.com/thephpleague/omnipay-sagepay",
     "license": "MIT",
@@ -30,7 +31,7 @@
     ],
     "autoload": {
         "psr-4": {
-            "Omnipay\\SagePay\\" : "src/"
+            "Omnipay\\Opayo\\" : "src/"
         }
     },
     "require": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,16 +8,15 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
          beStrictAboutTestsThatDoNotTestAnything="false">
     <testsuites>
         <testsuite name="Omnipay Test Suite">
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory>./src</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 </phpunit>

--- a/src/AbstractGateway.php
+++ b/src/AbstractGateway.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Omnipay\SagePay;
+namespace Omnipay\Opayo;
 
 use Omnipay\Common\AbstractGateway as OmnipayAbstractGateway;
-use Omnipay\SagePay\Traits\GatewayParamsTrait;
+use Omnipay\Opayo\Traits\GatewayParamsTrait;
 
 abstract class AbstractGateway extends OmnipayAbstractGateway implements ConstantsInterface
 {

--- a/src/ConstantsInterface.php
+++ b/src/ConstantsInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Omnipay\SagePay;
+namespace Omnipay\Opayo;
 
 /**
  * A convenient place to put all the gateway constants,
@@ -69,7 +69,7 @@ interface ConstantsInterface
     const CREATE_TOKEN_NO    = 0;
 
     /**
-     * Profile for Sage Pay Server hosted forms.
+     * Profile for Opayo Server hosted forms.
      * - NORMAL for full page forms.
      * - LOW for use in iframes.
      */
@@ -141,19 +141,19 @@ interface ConstantsInterface
      * and in response to different types of request.
      * @var string
      */
-    const SAGEPAY_STATUS_OK             = 'OK';
-    const SAGEPAY_STATUS_OK_REPEATED    = 'OK REPEATED';
-    const SAGEPAY_STATUS_PENDING        = 'PENDING';
-    const SAGEPAY_STATUS_NOTAUTHED      = 'NOTAUTHED';
-    const SAGEPAY_STATUS_REJECTED       = 'REJECTED';
-    const SAGEPAY_STATUS_AUTHENTICATED  = 'AUTHENTICATED';
-    const SAGEPAY_STATUS_REGISTERED     = 'REGISTERED';
-    const SAGEPAY_STATUS_3DAUTH         = '3DAUTH';
-    const SAGEPAY_STATUS_PPREDIRECT     = 'PPREDIRECT';
-    const SAGEPAY_STATUS_ABORT          = 'ABORT';
-    const SAGEPAY_STATUS_MALFORMED      = 'MALFORMED';
-    const SAGEPAY_STATUS_INVALID        = 'INVALID';
-    const SAGEPAY_STATUS_ERROR          = 'ERROR';
+    const OPAYO_STATUS_OK             = 'OK';
+    const OPAYO_STATUS_OK_REPEATED    = 'OK REPEATED';
+    const OPAYO_STATUS_PENDING        = 'PENDING';
+    const OPAYO_STATUS_NOTAUTHED      = 'NOTAUTHED';
+    const OPAYO_STATUS_REJECTED       = 'REJECTED';
+    const OPAYO_STATUS_AUTHENTICATED  = 'AUTHENTICATED';
+    const OPAYO_STATUS_REGISTERED     = 'REGISTERED';
+    const OPAYO_STATUS_3DAUTH         = '3DAUTH';
+    const OPAYO_STATUS_PPREDIRECT     = 'PPREDIRECT';
+    const OPAYO_STATUS_ABORT          = 'ABORT';
+    const OPAYO_STATUS_MALFORMED      = 'MALFORMED';
+    const OPAYO_STATUS_INVALID        = 'INVALID';
+    const OPAYO_STATUS_ERROR          = 'ERROR';
 
     /**
      * Raw values for AddressResult
@@ -193,7 +193,7 @@ interface ConstantsInterface
     const AVSCV2_RESULT_NOT_CHECKED         = 'DATA NOT CHECKED';
 
     /**
-     * Raw values for GiftAidResult (Sage Pay Serverv only)
+     * Raw values for GiftAidResult (Opayo Server only)
      * @var string
      */
     const GIFTAID_CHECKED_TRUE  = '1';
@@ -231,7 +231,7 @@ interface ConstantsInterface
     const PAYER_STATUS_UNVERIFIED   = 'UNVERIFIED';
 
     /**
-     * The raw recorded card type that was used (Sage Pay Server).
+     * The raw recorded card type that was used (Opayo Server).
      * TODO: a translation to OmniPay card brands would be useful.
      * @var string
      */

--- a/src/DirectGateway.php
+++ b/src/DirectGateway.php
@@ -1,21 +1,21 @@
 <?php
 
-namespace Omnipay\SagePay;
+namespace Omnipay\Opayo;
 
-use Omnipay\SagePay\Message\DirectAuthorizeRequest;
-use Omnipay\SagePay\Message\DirectCompleteAuthorizeRequest;
-use Omnipay\SagePay\Message\DirectPurchaseRequest;
-use Omnipay\SagePay\Message\SharedCaptureRequest;
-use Omnipay\SagePay\Message\SharedVoidRequest;
-use Omnipay\SagePay\Message\SharedAbortRequest;
-use Omnipay\SagePay\Message\SharedRefundRequest;
-use Omnipay\SagePay\Message\SharedRepeatAuthorizeRequest;
-use Omnipay\SagePay\Message\SharedRepeatPurchaseRequest;
-use Omnipay\SagePay\Message\DirectTokenRegistrationRequest;
-use Omnipay\SagePay\Message\SharedTokenRemovalRequest;
+use Omnipay\Opayo\Message\DirectAuthorizeRequest;
+use Omnipay\Opayo\Message\DirectCompleteAuthorizeRequest;
+use Omnipay\Opayo\Message\DirectPurchaseRequest;
+use Omnipay\Opayo\Message\SharedCaptureRequest;
+use Omnipay\Opayo\Message\SharedVoidRequest;
+use Omnipay\Opayo\Message\SharedAbortRequest;
+use Omnipay\Opayo\Message\SharedRefundRequest;
+use Omnipay\Opayo\Message\SharedRepeatAuthorizeRequest;
+use Omnipay\Opayo\Message\SharedRepeatPurchaseRequest;
+use Omnipay\Opayo\Message\DirectTokenRegistrationRequest;
+use Omnipay\Opayo\Message\SharedTokenRemovalRequest;
 
 /**
- * Sage Pay Direct Gateway
+ * Opayo Direct Gateway
  */
 
 class DirectGateway extends AbstractGateway
@@ -24,7 +24,7 @@ class DirectGateway extends AbstractGateway
 
     public function getName()
     {
-        return 'Sage Pay Direct';
+        return 'Opayo Direct';
     }
 
     /**

--- a/src/Extend/Item.php
+++ b/src/Extend/Item.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Omnipay\SagePay\Extend;
+namespace Omnipay\Opayo\Extend;
 
 /**
  * Extends the Item class to support properties

--- a/src/Extend/ItemInterface.php
+++ b/src/Extend/ItemInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Omnipay\SagePay\Extend;
+namespace Omnipay\Opayo\Extend;
 
 /**
  * Extends the Item class to support properties

--- a/src/FormGateway.php
+++ b/src/FormGateway.php
@@ -1,20 +1,20 @@
 <?php
 
-namespace Omnipay\SagePay;
+namespace Omnipay\Opayo;
 
-use Omnipay\SagePay\Message\Form\AuthorizeRequest;
-use Omnipay\SagePay\Message\Form\CompleteAuthorizeRequest;
-use Omnipay\SagePay\Message\Form\CompletePurchaseRequest;
-use Omnipay\SagePay\Message\Form\PurchaseRequest;
+use Omnipay\Opayo\Message\Form\AuthorizeRequest;
+use Omnipay\Opayo\Message\Form\CompleteAuthorizeRequest;
+use Omnipay\Opayo\Message\Form\CompletePurchaseRequest;
+use Omnipay\Opayo\Message\Form\PurchaseRequest;
 
 /**
- * Sage Pay Server Gateway
+ * Opayo Server Gateway
  */
 class FormGateway extends AbstractGateway
 {
     public function getName()
     {
-        return 'Sage Pay Form';
+        return 'Opayo Form';
     }
 
     /**

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -1,16 +1,16 @@
 <?php
 
-namespace Omnipay\SagePay\Message;
+namespace Omnipay\Opayo\Message;
 
 /**
- * Sage Pay Abstract Request.
- * Base for Sage Pay Server and Sage Pay Direct.
+ * Opayo Abstract Request.
+ * Base for Opayo Server and Opayo Direct.
  */
 use Omnipay\Common\Exception\InvalidRequestException;
-use Omnipay\SagePay\Extend\Item as ExtendItem;
+use Omnipay\Opayo\Extend\Item as ExtendItem;
 use Omnipay\Common\Message\AbstractRequest as OmnipayAbstractRequest;
-use Omnipay\SagePay\Traits\GatewayParamsTrait;
-use Omnipay\SagePay\ConstantsInterface;
+use Omnipay\Opayo\Traits\GatewayParamsTrait;
+use Omnipay\Opayo\ConstantsInterface;
 use Psr\Http\Message\ResponseInterface;
 
 abstract class AbstractRequest extends OmnipayAbstractRequest implements ConstantsInterface
@@ -52,7 +52,7 @@ abstract class AbstractRequest extends OmnipayAbstractRequest implements Constan
      * For MANY services, the URL fragment will be the lower case version
      * of the action.
      *
-     * @return string Sage Pay endpoint service name.
+     * @return string Opayo endpoint service name.
      */
     public function getService()
     {
@@ -105,7 +105,7 @@ abstract class AbstractRequest extends OmnipayAbstractRequest implements Constan
 
     /**
      * Get either the billing or the shipping address from
-     * the card object, mapped to Sage Pay field names.
+     * the card object, mapped to Opayo field names.
      *
      * @param string $type 'Billing' or 'Shipping'
      * @return array
@@ -114,7 +114,7 @@ abstract class AbstractRequest extends OmnipayAbstractRequest implements Constan
     {
         $card = $this->getCard();
 
-        // Mapping is Sage Pay name => Omnipay Name
+        // Mapping is Opayo name => Omnipay Name
 
         $mapping = [
             'Firstnames'    => 'FirstName',
@@ -130,8 +130,8 @@ abstract class AbstractRequest extends OmnipayAbstractRequest implements Constan
 
         $data = [];
 
-        foreach ($mapping as $sagepayName => $omnipayName) {
-            $data[$sagepayName] = call_user_func([$card, 'get' . $type . $omnipayName]);
+        foreach ($mapping as $opayoName => $omnipayName) {
+            $data[$opayoName] = call_user_func([$card, 'get' . $type . $omnipayName]);
         }
 
         // The state must not be set for non-US countries.
@@ -293,7 +293,7 @@ abstract class AbstractRequest extends OmnipayAbstractRequest implements Constan
     }
 
     /**
-     * Use this flag to indicate you wish to have a token generated and stored in the Sage Pay
+     * Use this flag to indicate you wish to have a token generated and stored in the Opayo
      * database and returned to you for future use.
      * Values set in constants CREATE_TOKEN_*
      *
@@ -331,7 +331,7 @@ abstract class AbstractRequest extends OmnipayAbstractRequest implements Constan
 
     /**
      * An optional flag to indicate if you wish to continue to store the
-     * Token in the SagePay token database for future use.
+     * Token in the Opayo token database for future use.
      * Values set in contants SET_TOKEN_*
      *
      * Note: this is just an override method. It is best to leave this unset,
@@ -455,9 +455,9 @@ abstract class AbstractRequest extends OmnipayAbstractRequest implements Constan
     }
 
     /**
-     * Filters out any characters that SagePay does not support from the item name.
+     * Filters out any characters that Opayo does not support from the item name.
      *
-     * Believe it or not, SagePay actually have separate rules for allowed characters
+     * Believe it or not, Opayo actually have separate rules for allowed characters
      * for item names and discount names, hence the need for two separate methods.
      *
      * @param string $name
@@ -474,7 +474,7 @@ abstract class AbstractRequest extends OmnipayAbstractRequest implements Constan
     }
 
     /**
-     * Filters out any characters that SagePay does not support from the item name for
+     * Filters out any characters that Opayo does not support from the item name for
      * the non-xml basket integration
      *
      * @param string $name
@@ -491,9 +491,9 @@ abstract class AbstractRequest extends OmnipayAbstractRequest implements Constan
     }
 
     /**
-     * Filters out any characters that SagePay does not support from the discount name.
+     * Filters out any characters that Opayo does not support from the discount name.
      *
-     * Believe it or not, SagePay actually have separate rules for allowed characters
+     * Believe it or not, Opayo actually have separate rules for allowed characters
      * for item names and discount names, hence the need for two separate methods.
      *
      * @param string $name

--- a/src/Message/AbstractRestRequest.php
+++ b/src/Message/AbstractRestRequest.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace Omnipay\SagePay\Message;
+namespace Omnipay\Opayo\Message;
 
 /**
- * Sage Pay Abstract Rest Request.
- * Base for Sage Pay Rest Server.
+ * Opayo Abstract Rest Request.
+ * Base for Opayo Rest Server.
  */
 use Omnipay\Common\Exception\InvalidRequestException;
-use Omnipay\SagePay\Extend\Item as ExtendItem;
-use Omnipay\SagePay\ConstantsInterface;
+use Omnipay\Opayo\Extend\Item as ExtendItem;
+use Omnipay\Opayo\ConstantsInterface;
 use Psr\Http\Message\ResponseInterface;
 
 abstract class AbstractRestRequest extends AbstractRequest implements ConstantsInterface
@@ -61,7 +61,7 @@ abstract class AbstractRestRequest extends AbstractRequest implements ConstantsI
      * The name of the service used in the endpoint to send the message.
      * With override for services used on specific parent services
      *
-     * @return string Sage Pay endpoint service name.
+     * @return string Opayo endpoint service name.
      */
     public function getSubService()
     {
@@ -160,7 +160,7 @@ abstract class AbstractRestRequest extends AbstractRequest implements ConstantsI
     /**
      * Set the credentialType field(s).
      *
-     * @param json $credentialType The credentialType for sagepay.
+     * @param json $credentialType The credentialType for Opayo.
      * @return $this
      */
     public function setCredentialType($credentialType)

--- a/src/Message/DirectAuthorizeRequest.php
+++ b/src/Message/DirectAuthorizeRequest.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace Omnipay\SagePay\Message;
+namespace Omnipay\Opayo\Message;
 
 /**
- * Sage Pay Direct Authorize Request
+ * Opayo Direct Authorize Request
  */
 
 class DirectAuthorizeRequest extends AbstractRequest
 {
     /**
-     * @var array Some mapping from Omnipay card brand codes to Sage Pay card brand codes.
+     * @var array Some mapping from Omnipay card brand codes to Opayo card brand codes.
      */
     protected $cardBrandMap = array(
         'mastercard' => 'MC',
@@ -101,7 +101,7 @@ class DirectAuthorizeRequest extends AbstractRequest
     }
 
     /**
-     * SagePay throws an error if passed an IPv6 address.
+     * Opayo throws an error if passed an IPv6 address.
      * Filter out addresses that are not IPv4 format.
      *
      * @return string|null The IPv4 IP addess string or null if not available in this format.
@@ -258,7 +258,7 @@ class DirectAuthorizeRequest extends AbstractRequest
     }
 
     /**
-     * @return string Get the card brand in a format expected by Sage Pay.
+     * @return string Get the card brand in a format expected by Opayo.
      */
     protected function getCardBrand()
     {
@@ -276,7 +276,7 @@ class DirectAuthorizeRequest extends AbstractRequest
     /**
      * Set the raw surcharge XML field.
      *
-     * @param string $surchargeXml The XML data formatted as per Sage Pay documentation.
+     * @param string $surchargeXml The XML data formatted as per Opayo documentation.
      * @return $this
      */
     public function setSurchargeXml($surchargeXml)

--- a/src/Message/DirectCompleteAuthorizeRequest.php
+++ b/src/Message/DirectCompleteAuthorizeRequest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Omnipay\SagePay\Message;
+namespace Omnipay\Opayo\Message;
 
 use Omnipay\Common\Exception\InvalidResponseException;
 
 /**
- * Sage Pay Direct Complete Authorize Request.
+ * Opayo Direct Complete Authorize Request.
  */
 class DirectCompleteAuthorizeRequest extends AbstractRequest
 {
@@ -18,7 +18,7 @@ class DirectCompleteAuthorizeRequest extends AbstractRequest
     {
         // Inconsistent letter case is intentional.
         // The issuing bank will return PaRes, but the merchant
-        // site must send this result as PARes to Sage Pay.
+        // site must send this result as PARes to Opayo.
 
         $data = array(
             'MD' => $this->getMd() ?: $this->httpRequest->request->get('MD'),

--- a/src/Message/DirectPurchaseRequest.php
+++ b/src/Message/DirectPurchaseRequest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Omnipay\SagePay\Message;
+namespace Omnipay\Opayo\Message;
 
 /**
- * Sage Pay Direct Purchase Request
+ * Opayo Direct Purchase Request
  */
 class DirectPurchaseRequest extends DirectAuthorizeRequest
 {

--- a/src/Message/DirectTokenRegistrationRequest.php
+++ b/src/Message/DirectTokenRegistrationRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Omnipay\SagePay\Message;
+namespace Omnipay\Opayo\Message;
 
 /**
  * Register a card with the gateway in exchange for a token.

--- a/src/Message/Form/AuthorizeRequest.php
+++ b/src/Message/Form/AuthorizeRequest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Omnipay\SagePay\Message\Form;
+namespace Omnipay\Opayo\Message\Form;
 
 /**
- * Sage Pay Form Authorize Request.
+ * Opayo Form Authorize Request.
  */
 
-use Omnipay\SagePay\Message\DirectAuthorizeRequest;
+use Omnipay\Opayo\Message\DirectAuthorizeRequest;
 use Omnipay\Common\Exception\InvalidRequestException;
 
 class AuthorizeRequest extends DirectAuthorizeRequest
@@ -65,7 +65,7 @@ class AuthorizeRequest extends DirectAuthorizeRequest
     ];
 
     /**
-     * Get the full set of Sage Pay Form data, most of which is encrypted.
+     * Get the full set of Opayo Form data, most of which is encrypted.
      * TxType is only PAYMENT, DEFERRED or AUTHENTICATE
      *
      * @reurn array
@@ -93,7 +93,7 @@ class AuthorizeRequest extends DirectAuthorizeRequest
     {
         $data = $this->getBaseAuthorizeData();
 
-        // Some [optional] parameters specific to Sage Pay Form..
+        // Some [optional] parameters specific to Opayo Form..
 
         if ($this->getCustomerName() !== null) {
             $data['CustomerName'] = $this->getCustomerName();

--- a/src/Message/Form/CompleteAuthorizeRequest.php
+++ b/src/Message/Form/CompleteAuthorizeRequest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Omnipay\SagePay\Message\Form;
+namespace Omnipay\Opayo\Message\Form;
 
 /**
- * Sage Pay Form Complete Authorize Response.
+ * Opayo Form Complete Authorize Response.
  */
 
-use Omnipay\SagePay\Message\AbstractRequest;
-use Omnipay\SagePay\Message\Response as GenericResponse;
+use Omnipay\Opayo\Message\AbstractRequest;
+use Omnipay\Opayo\Message\Response as GenericResponse;
 use Omnipay\Common\Exception\InvalidResponseException;
 use Omnipay\Common\Exception\InvalidRequestException;
 

--- a/src/Message/Form/CompletePurchaseRequest.php
+++ b/src/Message/Form/CompletePurchaseRequest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Omnipay\SagePay\Message\Form;
+namespace Omnipay\Opayo\Message\Form;
 
 /**
- * Sage Pay Form Complete Purchase Response.
+ * Opayo Form Complete Purchase Response.
  */
 
 class CompletePurchaseRequest extends CompleteAuthorizeRequest

--- a/src/Message/Form/PurchaseRequest.php
+++ b/src/Message/Form/PurchaseRequest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Omnipay\SagePay\Message\Form;
+namespace Omnipay\Opayo\Message\Form;
 
 /**
- * Sage Pay Direct Purchase Request
+ * Opayo Direct Purchase Request
  */
 class PurchaseRequest extends AuthorizeRequest
 {

--- a/src/Message/Form/Response.php
+++ b/src/Message/Form/Response.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace Omnipay\SagePay\Message\Form;
+namespace Omnipay\Opayo\Message\Form;
 
 /**
- * Sage Pay Form Authorize/Purchase Response (form POST redirect).
+ * Opayo Form Authorize/Purchase Response (form POST redirect).
  */
 
 use Omnipay\Common\Message\AbstractResponse;
 use Omnipay\Common\Message\RedirectResponseInterface;
-use Omnipay\SagePay\ConstantsInterface;
+use Omnipay\Opayo\ConstantsInterface;
 
 class Response extends AbstractResponse implements RedirectResponseInterface, ConstantsInterface
 {

--- a/src/Message/Response.php
+++ b/src/Message/Response.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace Omnipay\SagePay\Message;
+namespace Omnipay\Opayo\Message;
 
 use Omnipay\Common\Message\AbstractResponse;
 use Omnipay\Common\Message\RedirectResponseInterface;
 use Omnipay\Common\Message\RequestInterface;
-use Omnipay\SagePay\Traits\ResponseFieldsTrait;
-use Omnipay\SagePay\ConstantsInterface;
+use Omnipay\Opayo\Traits\ResponseFieldsTrait;
+use Omnipay\Opayo\ConstantsInterface;
 
 /**
- * Sage Pay Response
+ * Opayo Response
  */
 class Response extends AbstractResponse implements RedirectResponseInterface, ConstantsInterface
 {
@@ -18,7 +18,7 @@ class Response extends AbstractResponse implements RedirectResponseInterface, Co
     /**
      * Gateway Reference
      *
-     * Sage Pay requires the original VendorTxCode as well as 3 separate
+     * Opayo requires the original VendorTxCode as well as 3 separate
      * fields from the response object to capture or refund transactions at a later date.
      *
      * Active Merchant solves this dilemma by returning the gateway reference in the following
@@ -47,7 +47,7 @@ class Response extends AbstractResponse implements RedirectResponseInterface, Co
         }
 
         // Remaining transaction details supplied by the merchant site
-        // if not already in the response (it will be for Sage Pay Form).
+        // if not already in the response (it will be for Opayo Form).
 
         if (! array_key_exists('VendorTxCode', $reference)) {
             $reference['VendorTxCode'] = $this->getTransactionId();
@@ -66,7 +66,7 @@ class Response extends AbstractResponse implements RedirectResponseInterface, Co
      */
     public function isRedirect()
     {
-        return $this->getStatus() === static::SAGEPAY_STATUS_3DAUTH;
+        return $this->getStatus() === static::OPAYO_STATUS_3DAUTH;
     }
 
     /**
@@ -105,7 +105,7 @@ class Response extends AbstractResponse implements RedirectResponseInterface, Co
     }
 
     /**
-     * The Sage Pay ID to uniquely identify the transaction on their system.
+     * The Opayo ID to uniquely identify the transaction on their system.
      * Only present if Status is OK or OK REPEATED.
      *
      * @return string

--- a/src/Message/RestResponse.php
+++ b/src/Message/RestResponse.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace Omnipay\SagePay\Message;
+namespace Omnipay\Opayo\Message;
 
 use Omnipay\Common\Message\AbstractResponse;
 use Omnipay\Common\Message\RedirectResponseInterface;
 use Omnipay\Common\Message\RequestInterface;
-use Omnipay\SagePay\Traits\ResponseRestFieldsTrait;
-use Omnipay\SagePay\ConstantsInterface;
+use Omnipay\Opayo\Traits\ResponseRestFieldsTrait;
+use Omnipay\Opayo\ConstantsInterface;
 
 /**
- * Sage Pay Rest Response
+ * Opayo Rest Response
  */
 class RestResponse extends AbstractResponse implements RedirectResponseInterface, ConstantsInterface
 {
@@ -35,7 +35,7 @@ class RestResponse extends AbstractResponse implements RedirectResponseInterface
      */
     public function isRedirect()
     {
-        return $this->getStatus() === static::SAGEPAY_STATUS_3DAUTH;
+        return $this->getStatus() === static::OPAYO_STATUS_3DAUTH;
     }
 
     /**
@@ -81,7 +81,7 @@ class RestResponse extends AbstractResponse implements RedirectResponseInterface
     }
 
     /**
-     * The Sage Pay ID to uniquely identify the transaction on their system.
+     * The Opayo ID to uniquely identify the transaction on their system.
      * Only present if Status is OK or OK REPEATED.
      *
      * @return string

--- a/src/Message/ServerAuthorizeRequest.php
+++ b/src/Message/ServerAuthorizeRequest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Omnipay\SagePay\Message;
+namespace Omnipay\Opayo\Message;
 
 /**
- * Sage Pay Server Authorize Request
+ * Opayo Server Authorize Request
  */
 class ServerAuthorizeRequest extends DirectAuthorizeRequest
 {

--- a/src/Message/ServerAuthorizeResponse.php
+++ b/src/Message/ServerAuthorizeResponse.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Omnipay\SagePay\Message;
+namespace Omnipay\Opayo\Message;
 
 /**
- * Sage Pay Server Authorize Response
+ * Opayo Server Authorize Response
  */
 class ServerAuthorizeResponse extends Response
 {
@@ -27,7 +27,7 @@ class ServerAuthorizeResponse extends Response
     {
         return in_array(
             $this->getStatus(),
-            [static::SAGEPAY_STATUS_OK, static::SAGEPAY_STATUS_OK_REPEATED]
+            [static::OPAYO_STATUS_OK, static::OPAYO_STATUS_OK_REPEATED]
         );
     }
 

--- a/src/Message/ServerCompleteAuthorizeRequest.php
+++ b/src/Message/ServerCompleteAuthorizeRequest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Omnipay\SagePay\Message;
+namespace Omnipay\Opayo\Message;
 
 use Omnipay\Common\Exception\InvalidResponseException;
 
 /**
- * Sage Pay Server Complete Authorize Request
+ * Opayo Server Complete Authorize Request
  * DEPRECATED - use $gateway->notify()
  */
 class ServerCompleteAuthorizeRequest extends AbstractRequest
@@ -14,8 +14,8 @@ class ServerCompleteAuthorizeRequest extends AbstractRequest
      * Get the signature calculated from the three pieces of saved local
      * information:
      * - VendorTxCode - merchant site ID (aka transactionId).
-     * - VPSTxId - SagePay ID (aka transactionReference)
-     * - SecurityKey - SagePay one-use token.
+     * - VPSTxId - Opayo ID (aka transactionReference)
+     * - SecurityKey - Opayo one-use token.
      * and the POSTed transaction results.
      *
      * Note that the three items above are passed in as a single JSON structure

--- a/src/Message/ServerCompleteAuthorizeResponse.php
+++ b/src/Message/ServerCompleteAuthorizeResponse.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Omnipay\SagePay\Message;
+namespace Omnipay\Opayo\Message;
 
 use Omnipay\Common\Message\RequestInterface;
 
 /**
- * Sage Pay Server Complete Authorize Response
+ * Opayo Server Complete Authorize Response
  * DEPRECATED - use $gateway->notify()
  */
 class ServerCompleteAuthorizeResponse extends Response
@@ -28,9 +28,9 @@ class ServerCompleteAuthorizeResponse extends Response
     }
 
     /**
-     * Confirm (Sage Pay Server only)
+     * Confirm (Opayo Server only)
      *
-     * Notify Sage Pay you received the payment details and wish to confirm the payment, and
+     * Notify Opayo you received the payment details and wish to confirm the payment, and
      * provide a URL to forward the customer to.
      *
      * @param string URL to forward the customer to. Note this is different to your standard
@@ -43,9 +43,9 @@ class ServerCompleteAuthorizeResponse extends Response
     }
 
     /**
-     * Error (Sage Pay Server only)
+     * Error (Opayo Server only)
      *
-     * Notify Sage Pay you received the payment details but there was an error and the payment
+     * Notify Opayo you received the payment details but there was an error and the payment
      * cannot be completed. Error should be called rarely, and only when something unforseen
      * has happened on your server or database.
      *
@@ -59,9 +59,9 @@ class ServerCompleteAuthorizeResponse extends Response
     }
 
     /**
-     * Invalid (Sage Pay Server only)
+     * Invalid (Opayo Server only)
      *
-     * Notify Sage Pay you received the payment details but they were invalid and the payment
+     * Notify Opayo you received the payment details but they were invalid and the payment
      * cannot be completed. Invalid should be called if you are not happy with the contents
      * of the POST, such as the MD5 hash signatures did not match or you do not wish to proceed
      * with the order.
@@ -76,21 +76,21 @@ class ServerCompleteAuthorizeResponse extends Response
     }
 
     /**
-     * Respond to SagePay confirming or rejecting the payment.
+     * Respond to Opayo confirming or rejecting the payment.
      *
-     * Sage Pay Server does things backwards compared to every other gateway (including Sage Pay
+     * Opayo Server does things backwards compared to every other gateway (including Opayo
      * Direct). The return URL is called by their server, and they expect you to confirm receipt
      * and then pass a URL for them to forward the customer to.
      *
      * Because of this, an extra step is required. In your return controller, after calling
      * $gateway->completePurchase(), you should attempt to process the payment. You must then call
-     * either $response->confirm(), $response->error() or $response->invalid() to notify Sage Pay
+     * either $response->confirm(), $response->error() or $response->invalid() to notify Opayo
      * whether to complete the payment or not, and provide a URL to forward the customer to.
      *
-     * Keep in mind your original confirmPurchase() script is being called by Sage Pay, not
+     * Keep in mind your original confirmPurchase() script is being called by Opayo, not
      * the customer.
      *
-     * @param string The status to send to Sage Pay, either OK, INVALID or ERROR.
+     * @param string The status to send to Opayo, either OK, INVALID or ERROR.
      * @param string URL to forward the customer to. Note this is different to your standard
      *               return controller action URL.
      * @param string Optional human readable reasons for accepting the transaction.

--- a/src/Message/ServerNotifyRequest.php
+++ b/src/Message/ServerNotifyRequest.php
@@ -1,16 +1,16 @@
 <?php
 
-namespace Omnipay\SagePay\Message;
+namespace Omnipay\Opayo\Message;
 
 use Symfony\Component\HttpFoundation\Request as HttpRequest;
 use Omnipay\Common\Exception\InvalidResponseException;
 use Omnipay\Common\Message\NotificationInterface;
 use Omnipay\Common\Http\ClientInterface;
-use Omnipay\SagePay\Traits\ResponseFieldsTrait;
-use Omnipay\SagePay\Traits\ServerNotifyTrait;
+use Omnipay\Opayo\Traits\ResponseFieldsTrait;
+use Omnipay\Opayo\Traits\ServerNotifyTrait;
 
 /**
- * Sage Pay Server Notification.
+ * Opayo Server Notification.
  * The gateway will send the results of Server transactions here.
  */
 class ServerNotifyRequest extends AbstractRequest implements NotificationInterface
@@ -109,7 +109,7 @@ class ServerNotifyRequest extends AbstractRequest implements NotificationInterfa
     /**
      * Confirm
      *
-     * Notify Sage Pay you received the payment details and wish to confirm the payment.
+     * Notify Opayo you received the payment details and wish to confirm the payment.
      *
      * @param string URL to forward the customer to.
      * @param string Optional human readable reasons for accepting the transaction.
@@ -135,7 +135,7 @@ class ServerNotifyRequest extends AbstractRequest implements NotificationInterfa
     /**
      * Error
      *
-     * Notify Sage Pay you received the payment details but there was an error and the payment
+     * Notify Opayo you received the payment details but there was an error and the payment
      * cannot be completed.
      *
      * @param string URL to foward the customer to.
@@ -163,7 +163,7 @@ class ServerNotifyRequest extends AbstractRequest implements NotificationInterfa
     /**
      * Invalid
      *
-     * Notify Sage Pay you received *something* but the details were invalid and no payment
+     * Notify Opayo you received *something* but the details were invalid and no payment
      * cannot be completed. Invalid should be called if you are not happy with the contents
      * of the POST, such as the MD5 hash signatures did not match or you do not wish to proceed
      * with the order.
@@ -179,7 +179,7 @@ class ServerNotifyRequest extends AbstractRequest implements NotificationInterfa
     /**
      * Construct the response body.
      *
-     * @param string The status to send to Sage Pay, one of static::RESPONSE_STATUS_*
+     * @param string The status to send to Opayo, one of static::RESPONSE_STATUS_*
      * @param string URL to forward the customer to.
      * @param string Optional human readable reason for this response.
      */
@@ -198,9 +198,9 @@ class ServerNotifyRequest extends AbstractRequest implements NotificationInterfa
     }
 
     /**
-     * Respond to SagePay confirming or rejecting the notification.
+     * Respond to Opayo confirming or rejecting the notification.
      *
-     * @param string The status to send to Sage Pay, one of static::RESPONSE_STATUS_*
+     * @param string The status to send to Opayo, one of static::RESPONSE_STATUS_*
      * @param string URL to forward the customer to.
      * @param string Optional human readable reason for this response.
      */

--- a/src/Message/ServerPurchaseRequest.php
+++ b/src/Message/ServerPurchaseRequest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Omnipay\SagePay\Message;
+namespace Omnipay\Opayo\Message;
 
 /**
- * Sage Pay Server Purchase Request
+ * Opayo Server Purchase Request
  */
 class ServerPurchaseRequest extends ServerAuthorizeRequest
 {

--- a/src/Message/ServerRestAbortRequest.php
+++ b/src/Message/ServerRestAbortRequest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Omnipay\Opayo\Message;
+
+class ServerRestAbortRequest extends AbstractRestRequest
+{
+    public function getService()
+    {
+        return static::SERVICE_REST_INSTRUCTIONS;
+    }
+
+    public function getParentService()
+    {
+        return static::SERVICE_REST_TRANSACTIONS;
+    }
+
+    /**
+     * @return string the transaction type
+     */
+    public function getTxType()
+    {
+        return ucfirst(strtolower(static::TXTYPE_ABORT));
+    }
+
+    /**
+     * Instruction data.
+     *
+     * @return array
+     */
+    public function getData()
+    {
+        return [
+            'instructionType ' => $this->getTxType(),
+        ];
+    }
+
+    public function getParentServiceReference()
+    {
+        return $this->getParameter('transactionId');
+    }
+
+    /**
+     * @param array $data
+     * @return ServerRestInstructionResponse
+     */
+    protected function createResponse($data)
+    {
+        return $this->response = new ServerRestInstructionResponse($this, $data);
+    }
+}

--- a/src/Message/ServerRestAuthorizeRequest.php
+++ b/src/Message/ServerRestAuthorizeRequest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Omnipay\Opayo\Message;
+
+/**
+ * Opayo REST Server Purchase Request
+ */
+class ServerRestAuthorizeRequest extends ServerRestPurchaseRequest
+{
+    public function getTxType()
+    {
+        return ucfirst(strtolower(static::TXTYPE_DEFERRED));
+    }
+}

--- a/src/Message/ServerRestAuthorizeResponse.php
+++ b/src/Message/ServerRestAuthorizeResponse.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Omnipay\Opayo\Message;
+
+/**
+ * Opayo REST Server Authorize Response
+ */
+class ServerRestAuthorizeResponse extends RestResponse
+{
+    //
+}

--- a/src/Message/ServerRestCaptureRequest.php
+++ b/src/Message/ServerRestCaptureRequest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Omnipay\Opayo\Message;
+
+class ServerRestCaptureRequest extends AbstractRestRequest
+{
+    public function getService()
+    {
+        return static::SERVICE_REST_INSTRUCTIONS;
+    }
+
+    public function getParentService()
+    {
+        return static::SERVICE_REST_TRANSACTIONS;
+    }
+
+    /**
+     * @return string the transaction type
+     */
+    public function getTxType()
+    {
+        return ucfirst(strtolower(static::TXTYPE_RELEASE));
+    }
+
+    /**
+     * Instruction data.
+     *
+     * @return array
+     */
+    public function getData()
+    {
+        return [
+            'instructionType ' => $this->getTxType(),
+            'amount' => $this->getAmountInteger(),
+        ];
+    }
+
+    public function getParentServiceReference()
+    {
+        return $this->getParameter('transactionId');
+    }
+
+    /**
+     * @param array $data
+     * @return ServerRestInstructionResponse
+     */
+    protected function createResponse($data)
+    {
+        return $this->response = new ServerRestInstructionResponse($this, $data);
+    }
+}

--- a/src/Message/ServerRestCompletePurchaseRequest.php
+++ b/src/Message/ServerRestCompletePurchaseRequest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Omnipay\SagePay\Message;
+namespace Omnipay\Opayo\Message;
 
 use Omnipay\Common\Exception\InvalidResponseException;
-use Omnipay\SagePay\Message\ServerRestCompleteResponse;
+use Omnipay\Opayo\Message\ServerRestCompleteResponse;
 
 /**
- * Sage Pay REST Complete Purchase Request.
+ * Opayo REST Complete Purchase Request.
  */
 class ServerRestCompletePurchaseRequest extends AbstractRestRequest
 {

--- a/src/Message/ServerRestCompleteResponse.php
+++ b/src/Message/ServerRestCompleteResponse.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Omnipay\SagePay\Message;
+namespace Omnipay\Opayo\Message;
 
 /**
- * Sage Pay REST Server Complete Response
+ * Opayo REST Server Complete Response
  */
 class ServerRestCompleteResponse extends RestResponse
 {
@@ -13,6 +13,6 @@ class ServerRestCompleteResponse extends RestResponse
      */
     public function isSuccessful()
     {
-        return strtoupper($this->get3DSecureStatus() ?? $this->getStatus()) === static::SAGEPAY_STATUS_AUTHENTICATED;
+        return strtoupper($this->get3DSecureStatus() ?? $this->getStatus()) === static::OPAYO_STATUS_AUTHENTICATED;
     }
 }

--- a/src/Message/ServerRestInstructionResponse.php
+++ b/src/Message/ServerRestInstructionResponse.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Omnipay\SagePay\Message;
+namespace Omnipay\Opayo\Message;
 
 /**
- * Sage Pay REST Server Refund Response
+ * Opayo REST Server Refund Response
  */
 class ServerRestInstructionResponse extends RestResponse
 {

--- a/src/Message/ServerRestMerchantSessionKeyRequest.php
+++ b/src/Message/ServerRestMerchantSessionKeyRequest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Omnipay\SagePay\Message;
+namespace Omnipay\Opayo\Message;
 
 /**
- * Sage Pay REST Server Merchant Session Key Request
+ * Opayo REST Server Merchant Session Key Request
  */
 class ServerRestMerchantSessionKeyRequest extends AbstractRestRequest
 {

--- a/src/Message/ServerRestMerchantSessionKeyResponse.php
+++ b/src/Message/ServerRestMerchantSessionKeyResponse.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Omnipay\SagePay\Message;
+namespace Omnipay\Opayo\Message;
 
 /**
- * Sage Pay REST Server Merchant Session Key  Response
+ * Opayo REST Server Merchant Session Key  Response
  */
 class ServerRestMerchantSessionKeyResponse extends Response
 {

--- a/src/Message/ServerRestPurchaseRequest.php
+++ b/src/Message/ServerRestPurchaseRequest.php
@@ -50,7 +50,7 @@ class ServerRestPurchaseRequest extends AbstractRestRequest
         $data['transactionType'] = $this->getTxType();
         $data['vendorTxCode'] = $this->getTransactionId();
         $data['description'] = $this->getDescription();
-        $data['amount'] = (int) $this->getAmount();
+        $data['amount'] = $this->getAmountInteger();
         $data['currency'] = $this->getCurrency();
         $data['NotificationURL'] = $this->getNotifyUrl() ?: $this->getReturnUrl();
         $data['MD'] = $this->getMd();

--- a/src/Message/ServerRestPurchaseRequest.php
+++ b/src/Message/ServerRestPurchaseRequest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Omnipay\SagePay\Message;
+namespace Omnipay\Opayo\Message;
 
 /**
- * Sage Pay REST Server Purchase Request
+ * Opayo REST Server Purchase Request
  */
 class ServerRestPurchaseRequest extends AbstractRestRequest
 {
@@ -99,7 +99,7 @@ class ServerRestPurchaseRequest extends AbstractRestRequest
     /**
      * Set the strongCustomerAuthentication field(s).
      *
-     * @param json $strongCustomerAuthentication The strongCustomerAuthentication for sagepay.
+     * @param json $strongCustomerAuthentication The strongCustomerAuthentication for Opayo.
      * @return $this
      */
     public function setStrongCustomerAuthentication($strongCustomerAuthentication)

--- a/src/Message/ServerRestPurchaseResponse.php
+++ b/src/Message/ServerRestPurchaseResponse.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Omnipay\SagePay\Message;
+namespace Omnipay\Opayo\Message;
 
 /**
- * Sage Pay REST Server Purchase Response
+ * Opayo REST Server Purchase Response
  */
 class ServerRestPurchaseResponse extends RestResponse
 {

--- a/src/Message/ServerRestRefundRequest.php
+++ b/src/Message/ServerRestRefundRequest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Omnipay\SagePay\Message;
+namespace Omnipay\Opayo\Message;
 
-use Omnipay\SagePay\Message\ServerRestRefundResponse;
+use Omnipay\Opayo\Message\ServerRestRefundResponse;
 
 /**
- * Sage Pay REST Server Refund Request
+ * Opayo REST Server Refund Request
  */
 class ServerRestRefundRequest extends AbstractRestRequest
 {

--- a/src/Message/ServerRestRefundRequest.php
+++ b/src/Message/ServerRestRefundRequest.php
@@ -34,7 +34,7 @@ class ServerRestRefundRequest extends AbstractRestRequest
         $data['transactionType'] = $this->getTxType();
         $data['vendorTxCode'] = $this->getTransactionId();
         $data['description'] = $this->getDescription();
-        $data['amount'] = (int) $this->getAmount();
+        $data['amount'] = $this->getAmountInteger();
         // $data['currency'] = $this->getCurrency();
         $data['referenceTransactionId'] = $this->getReferenceTransactionId();
 

--- a/src/Message/ServerRestRefundResponse.php
+++ b/src/Message/ServerRestRefundResponse.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Omnipay\SagePay\Message;
+namespace Omnipay\Opayo\Message;
 
 /**
- * Sage Pay REST Server Refund Response
+ * Opayo REST Server Refund Response
  */
 class ServerRestRefundResponse extends RestResponse
 {

--- a/src/Message/ServerRestRepeatRequest.php
+++ b/src/Message/ServerRestRepeatRequest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Omnipay\SagePay\Message;
+namespace Omnipay\Opayo\Message;
 
-use Omnipay\SagePay\Message\ServerRestRepeatResponse;
+use Omnipay\Opayo\Message\ServerRestRepeatResponse;
 
 /**
- * Sage Pay REST Server Repeat Request
+ * Opayo REST Server Repeat Request
  */
 class ServerRestRepeatRequest extends AbstractRestRequest
 {

--- a/src/Message/ServerRestRepeatResponse.php
+++ b/src/Message/ServerRestRepeatResponse.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Omnipay\SagePay\Message;
+namespace Omnipay\Opayo\Message;
 
 /**
- * Sage Pay REST Server Repeat Response
+ * Opayo REST Server Repeat Response
  */
 class ServerRestRepeatResponse extends RestResponse
 {

--- a/src/Message/ServerRestRetrieveTransactionRequest.php
+++ b/src/Message/ServerRestRetrieveTransactionRequest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Omnipay\SagePay\Message;
+namespace Omnipay\Opayo\Message;
 
 /**
- * Sage Pay REST Server Purchase Request
+ * Opayo REST Server Purchase Request
  */
 class ServerRestRetrieveTransactionRequest extends AbstractRestRequest
 {

--- a/src/Message/ServerRestRetrieveTransactionResponse.php
+++ b/src/Message/ServerRestRetrieveTransactionResponse.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Omnipay\SagePay\Message;
+namespace Omnipay\Opayo\Message;
 
 /**
- * Sage Pay REST Retrieve Transaction Response
+ * Opayo REST Retrieve Transaction Response
  */
 class ServerRestRetrieveTransactionResponse extends RestResponse
 {

--- a/src/Message/ServerRestVoidRequest.php
+++ b/src/Message/ServerRestVoidRequest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Omnipay\SagePay\Message;
+namespace Omnipay\Opayo\Message;
 
-use Omnipay\SagePay\Message\ServerRestInstructionResponse;
-use Omnipay\SagePay\Message\ServerRestRefundResponse;
+use Omnipay\Opayo\Message\ServerRestInstructionResponse;
+use Omnipay\Opayo\Message\ServerRestRefundResponse;
 
 /**
- * Sage Pay REST Server Refund Request
+ * Opayo REST Server Refund Request
  */
 class ServerRestVoidRequest extends AbstractRestRequest
 {

--- a/src/Message/ServerTokenRegistrationRequest.php
+++ b/src/Message/ServerTokenRegistrationRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Omnipay\SagePay\Message;
+namespace Omnipay\Opayo\Message;
 
 class ServerTokenRegistrationRequest extends AbstractRequest
 {

--- a/src/Message/ServerTokenRegistrationResponse.php
+++ b/src/Message/ServerTokenRegistrationResponse.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Omnipay\SagePay\Message;
+namespace Omnipay\Opayo\Message;
 
 class ServerTokenRegistrationResponse extends Response
 {

--- a/src/Message/Shared/FetchTransaction.php
+++ b/src/Message/Shared/FetchTransaction.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Omnipay\SagePay\Message\Shared;
+namespace Omnipay\Opayo\Message\Shared;
 
 /**
- * Sage Pay fetch a transaction.
+ * Opayo fetch a transaction.
  * Reporting command: getTransactionDetail
  */
 
-use Omnipay\SagePay\Message\AbstractRequest;
+use Omnipay\Opayo\Message\AbstractRequest;
 
 class FetchTransaction extends AbstractRequest
 {

--- a/src/Message/SharedAbortRequest.php
+++ b/src/Message/SharedAbortRequest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Omnipay\SagePay\Message;
+namespace Omnipay\Opayo\Message;
 
 /**
- * Sage Pay Shared Abort Request
+ * Opayo Shared Abort Request
  */
 class SharedAbortRequest extends SharedVoidRequest
 {

--- a/src/Message/SharedCaptureRequest.php
+++ b/src/Message/SharedCaptureRequest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Omnipay\SagePay\Message;
+namespace Omnipay\Opayo\Message;
 
 /**
- * Sage Pay Direct Capture Request.
+ * Opayo Direct Capture Request.
  * Performs a release or an authorise, depending on the
  * setting 'useAuthenticate'.
  */

--- a/src/Message/SharedRefundRequest.php
+++ b/src/Message/SharedRefundRequest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Omnipay\SagePay\Message;
+namespace Omnipay\Opayo\Message;
 
 /**
- * Sage Pay Shared Refund Request
+ * Opayo Shared Refund Request
  */
 class SharedRefundRequest extends AbstractRequest
 {

--- a/src/Message/SharedRepeatAuthorizeRequest.php
+++ b/src/Message/SharedRepeatAuthorizeRequest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Omnipay\SagePay\Message;
+namespace Omnipay\Opayo\Message;
 
 use Omnipay\Common\Exception\InvalidRequestException;
 use Omnipay\Common\Helper;
 
 /**
- * Sage Pay Direct Repeat Authorize Request
+ * Opayo Direct Repeat Authorize Request
  */
 class SharedRepeatAuthorizeRequest extends AbstractRequest
 {
@@ -57,7 +57,7 @@ class SharedRepeatAuthorizeRequest extends AbstractRequest
 
         $data['Description'] = $this->getDescription();
 
-        // Sage Pay's unique reference for the ORIGINAL transaction
+        // Opayo's unique reference for the ORIGINAL transaction
 
         $data['RelatedVendorTxCode'] = $this->getRelatedTransactionId();
         $data['RelatedVPSTxId'] = $this->getVpsTxId();

--- a/src/Message/SharedRepeatPurchaseRequest.php
+++ b/src/Message/SharedRepeatPurchaseRequest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Omnipay\SagePay\Message;
+namespace Omnipay\Opayo\Message;
 
 use Omnipay\Common\Helper;
 
 /**
- * Sage Pay Direct Repeat Authorize Request
+ * Opayo Direct Repeat Authorize Request
  */
 class SharedRepeatPurchaseRequest extends SharedRepeatAuthorizeRequest
 {

--- a/src/Message/SharedTokenRemovalRequest.php
+++ b/src/Message/SharedTokenRemovalRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Omnipay\SagePay\Message;
+namespace Omnipay\Opayo\Message;
 
 class SharedTokenRemovalRequest extends AbstractRequest
 {

--- a/src/Message/SharedVoidRequest.php
+++ b/src/Message/SharedVoidRequest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Omnipay\SagePay\Message;
+namespace Omnipay\Opayo\Message;
 
 /**
- * Sage Pay Shared Void Request
+ * Opayo Shared Void Request
  */
 class SharedVoidRequest extends AbstractRequest
 {

--- a/src/RestServerGateway.php
+++ b/src/RestServerGateway.php
@@ -3,6 +3,7 @@
 namespace Omnipay\Opayo;
 
 use Omnipay\Opayo\Message\ServerRestAuthorizeRequest;
+use Omnipay\Opayo\Message\ServerRestCaptureRequest;
 use Omnipay\Opayo\Message\ServerRestCompletePurchaseRequest;
 use Omnipay\Opayo\Message\ServerRestMerchantSessionKeyRequest;
 use Omnipay\Opayo\Message\ServerRestPurchaseRequest;
@@ -61,6 +62,17 @@ class RestServerGateway extends ServerGateway
     public function authorize(array $parameters = [])
     {
         return $this->createRequest(ServerRestAuthorizeRequest::class, $parameters);
+    }
+
+    /**
+     * Take payment for ("release") a previously deferred transaction. You can specify an amount to capture up to and
+     * including the original amount of the deferred transaction, but no more. Whether the full amount is captured or
+     * not, only a single release can occur against each deferred transaction, after which the transaction is closed.
+     * You may not perform a partial capture and then come back and attempt to take the rest of the money.
+     */
+    public function capture(array $parameters = [])
+    {
+        return $this->createRequest(ServerRestCaptureRequest::class, $parameters);
     }
 
     /**

--- a/src/RestServerGateway.php
+++ b/src/RestServerGateway.php
@@ -2,6 +2,7 @@
 
 namespace Omnipay\Opayo;
 
+use Omnipay\Opayo\Message\ServerRestAbortRequest;
 use Omnipay\Opayo\Message\ServerRestAuthorizeRequest;
 use Omnipay\Opayo\Message\ServerRestCaptureRequest;
 use Omnipay\Opayo\Message\ServerRestCompletePurchaseRequest;
@@ -73,6 +74,16 @@ class RestServerGateway extends ServerGateway
     public function capture(array $parameters = [])
     {
         return $this->createRequest(ServerRestCaptureRequest::class, $parameters);
+    }
+
+    /**
+     * Abort a previously deferred transaction. This cannot be reversed and cannot be for a partial amount. Once the
+     * transaction is aborted, the shadow will be removed from the customer's card so their funds are no longer reserved
+     * and the transaction cannot be captured (released).
+     */
+    public function abort(array $parameters = [])
+    {
+        return $this->createRequest(ServerRestAbortRequest::class, $parameters);
     }
 
     /**

--- a/src/RestServerGateway.php
+++ b/src/RestServerGateway.php
@@ -2,6 +2,7 @@
 
 namespace Omnipay\Opayo;
 
+use Omnipay\Opayo\Message\ServerRestAuthorizeRequest;
 use Omnipay\Opayo\Message\ServerRestCompletePurchaseRequest;
 use Omnipay\Opayo\Message\ServerRestMerchantSessionKeyRequest;
 use Omnipay\Opayo\Message\ServerRestPurchaseRequest;
@@ -43,23 +44,37 @@ class RestServerGateway extends ServerGateway
     /**
      * Create merchant session key (MSK).
      */
-    public function createMerchantSessionKey(array $parameters = array())
+    public function createMerchantSessionKey(array $parameters = [])
     {
         return $this->createRequest(ServerRestMerchantSessionKeyRequest::class, $parameters);
     }
 
     /**
+     * Authorize is similar to purchase except that the transaction is deferred - a "shadow" transaction is placed on
+     * the customer's card to reserve the funds needed to make payment, but the money is not actually transferred. The
+     * transaction must then be captured ("released" in Opayo terminology) to actually take the money.
+     *
+     * Opayo will automatically abort any deferred transactions that have not been released after 30 days. However, some
+     * card providers may remove the shadow after 6 days so that the customer can spend those funds elsewhere. You can
+     * also manually abort a deferred transaction if you are unable to fulfil the purchase.
+     */
+    public function authorize(array $parameters = [])
+    {
+        return $this->createRequest(ServerRestAuthorizeRequest::class, $parameters);
+    }
+
+    /**
      * Purchase and handling of return from 3D Secure redirection.
      */
-    public function purchase(array $parameters = array())
+    public function purchase(array $parameters = [])
     {
         return $this->createRequest(ServerRestPurchaseRequest::class, $parameters);
     }
 
     /**
-     * Handle purchase notifcation callback.
+     * Handle purchase notification callback.
      */
-    public function complete(array $parameters = array())
+    public function complete(array $parameters = [])
     {
         return $this->createRequest(ServerRestCompletePurchaseRequest::class, $parameters);
     }
@@ -67,7 +82,7 @@ class RestServerGateway extends ServerGateway
     /**
      * Get transaction information from Opayo.
      */
-    public function getTransaction(array $parameters = array())
+    public function getTransaction(array $parameters = [])
     {
         return $this->createRequest(ServerRestRetrieveTransactionRequest::class, $parameters);
     }
@@ -75,7 +90,7 @@ class RestServerGateway extends ServerGateway
     /**
      * Refund request.
      */
-    public function refund(array $parameters = array())
+    public function refund(array $parameters = [])
     {
         return $this->createRequest(ServerRestRefundRequest::class, $parameters);
     }
@@ -83,7 +98,7 @@ class RestServerGateway extends ServerGateway
     /**
      * Repeat request.
      */
-    public function repeat(array $parameters = array())
+    public function repeat(array $parameters = [])
     {
         return $this->createRequest(ServerRestRepeatRequest::class, $parameters);
     }
@@ -91,7 +106,7 @@ class RestServerGateway extends ServerGateway
     /**
      * Void request.
      */
-    public function void(array $parameters = array())
+    public function void(array $parameters = [])
     {
         return $this->createRequest(ServerRestVoidRequest::class, $parameters);
     }

--- a/src/RestServerGateway.php
+++ b/src/RestServerGateway.php
@@ -1,25 +1,25 @@
 <?php
 
-namespace Omnipay\SagePay;
+namespace Omnipay\Opayo;
 
-use Omnipay\SagePay\Message\ServerRestCompletePurchaseRequest;
-use Omnipay\SagePay\Message\ServerRestMerchantSessionKeyRequest;
-use Omnipay\SagePay\Message\ServerRestPurchaseRequest;
-use Omnipay\SagePay\Message\ServerRestRefundRequest;
-use Omnipay\SagePay\Message\ServerRestRepeatRequest;
-use Omnipay\SagePay\Message\ServerRestRetrieveTransactionRequest;
-use Omnipay\SagePay\Message\ServerRestVoidRequest;
+use Omnipay\Opayo\Message\ServerRestCompletePurchaseRequest;
+use Omnipay\Opayo\Message\ServerRestMerchantSessionKeyRequest;
+use Omnipay\Opayo\Message\ServerRestPurchaseRequest;
+use Omnipay\Opayo\Message\ServerRestRefundRequest;
+use Omnipay\Opayo\Message\ServerRestRepeatRequest;
+use Omnipay\Opayo\Message\ServerRestRetrieveTransactionRequest;
+use Omnipay\Opayo\Message\ServerRestVoidRequest;
 
 /**
- * Sage Pay Rest Server Gateway
+ * Opayo Rest Server Gateway
  */
 class RestServerGateway extends ServerGateway
 {
     public function getName()
     {
-        return 'Sage Pay REST Server';
+        return 'Opayo REST Server';
     }
-    
+
     public function getUsername()
     {
         return $this->getParameter('username');
@@ -65,7 +65,7 @@ class RestServerGateway extends ServerGateway
     }
 
     /**
-     * Get transaction information from Sage.
+     * Get transaction information from Opayo.
      */
     public function getTransaction(array $parameters = array())
     {

--- a/src/ServerGateway.php
+++ b/src/ServerGateway.php
@@ -1,24 +1,24 @@
 <?php
 
-namespace Omnipay\SagePay;
+namespace Omnipay\Opayo;
 
 // CHECKME: do we really need these?
-use Omnipay\SagePay\Message\ServerAuthorizeRequest;
-use Omnipay\SagePay\Message\ServerCompleteAuthorizeRequest;
-use Omnipay\SagePay\Message\ServerPurchaseRequest;
-use Omnipay\SagePay\Message\ServerNotifyRequest;
-use Omnipay\SagePay\Message\SharedTokenRemovalRequest;
-use Omnipay\SagePay\Message\ServerTokenRegistrationRequest;
-use Omnipay\SagePay\Message\ServerTokenRegistrationCompleteRequest;
+use Omnipay\Opayo\Message\ServerAuthorizeRequest;
+use Omnipay\Opayo\Message\ServerCompleteAuthorizeRequest;
+use Omnipay\Opayo\Message\ServerPurchaseRequest;
+use Omnipay\Opayo\Message\ServerNotifyRequest;
+use Omnipay\Opayo\Message\SharedTokenRemovalRequest;
+use Omnipay\Opayo\Message\ServerTokenRegistrationRequest;
+use Omnipay\Opayo\Message\ServerTokenRegistrationCompleteRequest;
 
 /**
- * Sage Pay Server Gateway
+ * Opayo Server Gateway
  */
 class ServerGateway extends DirectGateway
 {
     public function getName()
     {
-        return 'Sage Pay Server';
+        return 'Opayo Server';
     }
 
     /**

--- a/src/Traits/GatewayParamsTrait.php
+++ b/src/Traits/GatewayParamsTrait.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Omnipay\SagePay\Traits;
+namespace Omnipay\Opayo\Traits;
 
 //use Omnipay\Common\Exception\InvalidResponseException;
 //use Omnipay\Common\Message\NotificationInterface;
-//use Omnipay\SagePay\Message\Response;
+//use Omnipay\Opayo\Message\Response;
 
 /**
  * Parameters that can be set at the gateway class, and so
@@ -103,7 +103,7 @@ trait GatewayParamsTrait
     }
 
     /**
-     * Set language to instruct sagepay, on which language will be seen
+     * Set language to instruct Opayo, on which language will be seen
      * on payment pages.
      *
      * @param string $value ISO 639 alpha-2 character language code.
@@ -203,7 +203,7 @@ trait GatewayParamsTrait
     }
 
     /**
-     * @return string|null Encryption key for Sage Pay Form
+     * @return string|null Encryption key for Opayo Form
      */
     public function getEncryptionKey()
     {
@@ -211,7 +211,7 @@ trait GatewayParamsTrait
     }
 
     /**
-     * @param string $value Encryption key for Sage Pay Form; aka form password
+     * @param string $value Encryption key for Opayo Form; aka form password
      * @return $this
      */
     public function setEncryptionKey($value)

--- a/src/Traits/ResponseFieldsTrait.php
+++ b/src/Traits/ResponseFieldsTrait.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Omnipay\SagePay\Traits;
+namespace Omnipay\Opayo\Traits;
 
 /**
  * Response fields shared between the Direct/Server response class and
@@ -28,10 +28,10 @@ trait ResponseFieldsTrait
      */
     public function isSuccessful()
     {
-        return $this->getStatus() === static::SAGEPAY_STATUS_OK
-            || $this->getStatus() === static::SAGEPAY_STATUS_OK_REPEATED
-            || $this->getStatus() === static::SAGEPAY_STATUS_REGISTERED
-            || $this->getStatus() === static::SAGEPAY_STATUS_AUTHENTICATED;
+        return $this->getStatus() === static::OPAYO_STATUS_OK
+            || $this->getStatus() === static::OPAYO_STATUS_OK_REPEATED
+            || $this->getStatus() === static::OPAYO_STATUS_REGISTERED
+            || $this->getStatus() === static::OPAYO_STATUS_AUTHENTICATED;
     }
 
     /**
@@ -58,7 +58,7 @@ trait ResponseFieldsTrait
     /**
      * The raw status code.
      *
-     * @return string One of static::SAGEPAY_STATUS_*
+     * @return string One of static::OPAYO_STATUS_*
      */
     public function getStatus()
     {
@@ -68,7 +68,7 @@ trait ResponseFieldsTrait
     /**
      * The raw status code.
      *
-     * @return string One of static::SAGEPAY_STATUS_*
+     * @return string One of static::OPAYO_STATUS_*
      */
     public function getCode()
     {
@@ -86,7 +86,7 @@ trait ResponseFieldsTrait
     }
 
     /**
-     * Sage Pay unique Authorisation Code for a successfully authorised transaction.
+     * Opayo unique Authorisation Code for a successfully authorised transaction.
      * Only present if Status is OK
      *
      * @return string
@@ -99,7 +99,7 @@ trait ResponseFieldsTrait
     /**
      * This is the response from AVS and CV2 checks.
      * Provided for Vendor info and backward compatibility with the
-     * banks. Rules set up in MySagePay will accept or reject
+     * banks. Rules set up in MyOpayo will accept or reject
      * the transaction based on these values.
      *
      * More detailed results are split out in the next three fields:
@@ -215,7 +215,7 @@ trait ResponseFieldsTrait
 
     /**
      * Raw expiry date for the card, "MMYY" format by default.
-     * The expiry date is available for Sage Pay Direct responses, even if the
+     * The expiry date is available for Opayo Direct responses, even if the
      * remaining card details are not.
      * Also supports custom formats.
      *

--- a/src/Traits/ResponseRestFieldsTrait.php
+++ b/src/Traits/ResponseRestFieldsTrait.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Omnipay\SagePay\Traits;
+namespace Omnipay\Opayo\Traits;
 
 /**
  * Response fields shared between the Direct/Server response class and
@@ -28,10 +28,10 @@ trait ResponseRestFieldsTrait
      */
     public function isSuccessful()
     {
-        return $this->getStatus() === static::SAGEPAY_STATUS_OK
-            || $this->getStatus() === static::SAGEPAY_STATUS_OK_REPEATED
-            || $this->getStatus() === static::SAGEPAY_STATUS_REGISTERED
-            || $this->getStatus() === static::SAGEPAY_STATUS_AUTHENTICATED;
+        return $this->getStatus() === static::OPAYO_STATUS_OK
+            || $this->getStatus() === static::OPAYO_STATUS_OK_REPEATED
+            || $this->getStatus() === static::OPAYO_STATUS_REGISTERED
+            || $this->getStatus() === static::OPAYO_STATUS_AUTHENTICATED;
     }
 
     /**
@@ -58,7 +58,7 @@ trait ResponseRestFieldsTrait
     /**
      * The raw status code.
      *
-     * @return string One of static::SAGEPAY_STATUS_*
+     * @return string One of static::OPAYO_STATUS_*
      */
     public function getStatus()
     {
@@ -68,7 +68,7 @@ trait ResponseRestFieldsTrait
     /**
      * The raw status code.
      *
-     * @return string One of static::SAGEPAY_STATUS_*
+     * @return string One of static::OPAYO_STATUS_*
      */
     public function getCode()
     {
@@ -78,7 +78,7 @@ trait ResponseRestFieldsTrait
     /**
      * The raw status code.
      *
-     * @return string One of static::SAGEPAY_STATUS_*
+     * @return string One of static::OPAYO_STATUS_*
      */
     public function getStatusCode()
     {
@@ -106,7 +106,7 @@ trait ResponseRestFieldsTrait
     }
 
     /**
-     * Sage Pay unique Authorisation Code for a successfully authorised transaction.
+     * Opayo unique Authorisation Code for a successfully authorised transaction.
      * Only present if Status is OK
      *
      * @return string
@@ -117,7 +117,7 @@ trait ResponseRestFieldsTrait
     }
 
     /**
-     * Sage Pay unique Authorisation Code for a successfully authorised transaction.
+     * Opayo unique Authorisation Code for a successfully authorised transaction.
      * Only present if Status is OK
      *
      * @return string
@@ -128,7 +128,7 @@ trait ResponseRestFieldsTrait
     }
 
     /**
-     * Sage Pay unique Authorisation Code for a successfully authorised transaction.
+     * Opayo unique Authorisation Code for a successfully authorised transaction.
      * Only present if Status is OK
      *
      * @return array
@@ -146,7 +146,7 @@ trait ResponseRestFieldsTrait
     /**
      * This is the response from AVS and CV2 checks.
      * Provided for Vendor info and backward compatibility with the
-     * banks. Rules set up in MySagePay will accept or reject
+     * banks. Rules set up in MyOpayo will accept or reject
      * the transaction based on these values.
      *
      * More detailed results are split out in the next three fields:
@@ -268,7 +268,7 @@ trait ResponseRestFieldsTrait
 
     /**
      * Raw expiry date for the card, "MMYY" format by default.
-     * The expiry date is available for Sage Pay Direct responses, even if the
+     * The expiry date is available for Opayo Direct responses, even if the
      * remaining card details are not.
      * Also supports custom formats.
      *

--- a/src/Traits/ServerNotifyTrait.php
+++ b/src/Traits/ServerNotifyTrait.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Omnipay\SagePay\Traits;
+namespace Omnipay\Opayo\Traits;
 
 use Omnipay\Common\Exception\InvalidResponseException;
 use Omnipay\Common\Message\NotificationInterface;
-use Omnipay\SagePay\Message\Response;
+use Omnipay\Opayo\Message\Response;
 
 /**
  * Data access methods shared between the ServerNotificationRequest and
@@ -34,9 +34,9 @@ trait ServerNotifyTrait
         $VPSTxId = $this->getVPSTxId();
 
         if ($this->getTxType() === Response::TXTYPE_TOKEN
-            && $this->getStatus() === Response::SAGEPAY_STATUS_OK
+            && $this->getStatus() === Response::OPAYO_STATUS_OK
         ) {
-            // For some bizarre reason, the VPSTxId is hashed at the Sage Pay gateway
+            // For some bizarre reason, the VPSTxId is hashed at the Opayo gateway
             // without its curly brackets, so we must do the same to validate the hash.
             // This only happens for a valid TOKEN request, and not for an aborted
             // TOKEN request.
@@ -64,7 +64,7 @@ trait ServerNotifyTrait
         );
 
         if ($this->getTxType() !== Response::TXTYPE_TOKEN
-            || $this->getStatus() !== Response::SAGEPAY_STATUS_OK
+            || $this->getStatus() !== Response::OPAYO_STATUS_OK
         ) {
             // Do not use any of these fields for a successful TOKEN transaction,
             // even though some of them may be present.
@@ -122,15 +122,15 @@ trait ServerNotifyTrait
 
         $status = $this->getStatus();
 
-        if ($status === Response::SAGEPAY_STATUS_OK
-            || $status === Response::SAGEPAY_STATUS_OK_REPEATED
-            || $status === Response::SAGEPAY_STATUS_AUTHENTICATED
-            || $status === Response::SAGEPAY_STATUS_REGISTERED
+        if ($status === Response::OPAYO_STATUS_OK
+            || $status === Response::OPAYO_STATUS_OK_REPEATED
+            || $status === Response::OPAYO_STATUS_AUTHENTICATED
+            || $status === Response::OPAYO_STATUS_REGISTERED
         ) {
             return static::STATUS_COMPLETED;
         }
 
-        if ($status === Response::SAGEPAY_STATUS_PENDING) {
+        if ($status === Response::OPAYO_STATUS_PENDING) {
             return static::STATUS_PENDING;
         }
 

--- a/tests/DirectGatewayTest.php
+++ b/tests/DirectGatewayTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Omnipay\SagePay;
+namespace Omnipay\Opayo;
 
 use Omnipay\Tests\GatewayTestCase;
 

--- a/tests/FormGatewayTest.php
+++ b/tests/FormGatewayTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Omnipay\SagePay;
+namespace Omnipay\Opayo;
 
 use Omnipay\Tests\GatewayTestCase;
 
@@ -40,7 +40,7 @@ class FormGatewayTest extends GatewayTestCase
 
     public function testInheritsDirectGateway()
     {
-        $this->assertInstanceOf(\Omnipay\SagePay\FormGateway::class, $this->gateway);
+        $this->assertInstanceOf(\Omnipay\Opayo\FormGateway::class, $this->gateway);
     }
 
     public function testAuthorizeSuccess()

--- a/tests/Message/DirectAuthorizeRequestTest.php
+++ b/tests/Message/DirectAuthorizeRequestTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Omnipay\SagePay\Message;
+namespace Omnipay\Opayo\Message;
 
 use Omnipay\Tests\TestCase;
 
@@ -129,7 +129,7 @@ class DirectAuthorizeRequestTest extends TestCase
     public function testBasketExtendItem()
     {
         $items = new \Omnipay\Common\ItemBag(array(
-            new \Omnipay\SagePay\Extend\Item(array(
+            new \Omnipay\Opayo\Extend\Item(array(
                 'name' => 'Name',
                 'description' => 'Description',
                 'quantity' => 1,
@@ -214,7 +214,7 @@ class DirectAuthorizeRequestTest extends TestCase
         $data = $this->request->getData();
 
         // these must be empty string, not null
-        // (otherwise Guzzle ignores them, and SagePay throws a fit)
+        // (otherwise Guzzle ignores them, and Opayo throws a fit)
         $this->assertSame('', $data['BillingState']);
         $this->assertSame('', $data['DeliveryState']);
     }
@@ -259,7 +259,7 @@ class DirectAuthorizeRequestTest extends TestCase
         $this->assertNull($data['BillingAddress2']);
 
         // This tests that the BillingAddress2 may be left unset,
-        // which defaults to null. When it is sent to SagePay, it gets
+        // which defaults to null. When it is sent to Opayo, it gets
         // converted to an empty string. I'm not clear how that would be
         // tested.
     }
@@ -329,7 +329,7 @@ class DirectAuthorizeRequestTest extends TestCase
         $this->request->setUseOldBasketFormat(true);
 
         $items = new \Omnipay\Common\ItemBag(array(
-            new \Omnipay\SagePay\Extend\Item(array(
+            new \Omnipay\Opayo\Extend\Item(array(
                 'name' => "Pioneer NSDV99 DVD-Surround Sound System",
                 'quantity' => 3,
                 'price' => 4.35,
@@ -348,7 +348,7 @@ class DirectAuthorizeRequestTest extends TestCase
         $this->request->setUseOldBasketFormat(true);
 
         $items = new \Omnipay\Common\ItemBag(array(
-            new \Omnipay\SagePay\Extend\Item(array(
+            new \Omnipay\Opayo\Extend\Item(array(
                 'name' => "Pioneer NSDV99 DVD-Surround Sound System",
                 'quantity' => 3,
                 'price' => 4.35,
@@ -370,7 +370,7 @@ class DirectAuthorizeRequestTest extends TestCase
         $this->request->setUseOldBasketFormat(true);
 
         $items = new \Omnipay\Common\ItemBag(array(
-            new \Omnipay\SagePay\Extend\Item(array(
+            new \Omnipay\Opayo\Extend\Item(array(
                 'name' => "Pioneer NSDV99 DVD-Surround Sound System",
                 'quantity' => 3,
                 'price' => 4.35,
@@ -390,7 +390,7 @@ class DirectAuthorizeRequestTest extends TestCase
         $this->request->setUseOldBasketFormat(true);
 
         $items = new \Omnipay\Common\ItemBag(array(
-            new \Omnipay\SagePay\Extend\Item(array(
+            new \Omnipay\Opayo\Extend\Item(array(
                 // [] and ::: are reserved
                 'name' => "[SKU-ABC]Pioneer::: NSDV99 DVD-Surround Sound System .-{};_@()",
                 'quantity' => 3,

--- a/tests/Message/DirectCompleteAuthorizeRequestTest.php
+++ b/tests/Message/DirectCompleteAuthorizeRequestTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Omnipay\SagePay\Message;
+namespace Omnipay\Opayo\Message;
 
 use Omnipay\Tests\TestCase;
 use Mockery as m;

--- a/tests/Message/DirectPurchaseRequestTest.php
+++ b/tests/Message/DirectPurchaseRequestTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Omnipay\SagePay\Message;
+namespace Omnipay\Opayo\Message;
 
 use Omnipay\Tests\TestCase;
 

--- a/tests/Message/DirectTokenRequestTest.php
+++ b/tests/Message/DirectTokenRequestTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Omnipay\SagePay\Message;
+namespace Omnipay\Opayo\Message;
 
 use Omnipay\Tests\TestCase;
 

--- a/tests/Message/ResponseTest.php
+++ b/tests/Message/ResponseTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Omnipay\SagePay\Message;
+namespace Omnipay\Opayo\Message;
 
 use Omnipay\Common\Message\RequestInterface;
 use Omnipay\Tests\TestCase;

--- a/tests/Message/ServerAuthorizeRequestTest.php
+++ b/tests/Message/ServerAuthorizeRequestTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Omnipay\SagePay\Message;
+namespace Omnipay\Opayo\Message;
 
 use Omnipay\Tests\TestCase;
 

--- a/tests/Message/ServerAuthorizeResponseTest.php
+++ b/tests/Message/ServerAuthorizeResponseTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Omnipay\SagePay\Message;
+namespace Omnipay\Opayo\Message;
 
 use Omnipay\Tests\TestCase;
 

--- a/tests/Message/ServerCompleteAuthorizeResponseTest.php
+++ b/tests/Message/ServerCompleteAuthorizeResponseTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Omnipay\SagePay\Message;
+namespace Omnipay\Opayo\Message;
 
 use Omnipay\Tests\TestCase;
 use Mockery as m;
@@ -85,7 +85,7 @@ class ServerCompleteAuthorizeResponseTest extends TestCase
 
     public function testConfirm()
     {
-        $response = m::mock('\Omnipay\SagePay\Message\ServerCompleteAuthorizeResponse')->makePartial();
+        $response = m::mock('\Omnipay\Opayo\Message\ServerCompleteAuthorizeResponse')->makePartial();
         $response->shouldReceive('sendResponse')->once()->with('OK', 'https://www.example.com/', 'detail');
 
         $response->confirm('https://www.example.com/', 'detail');
@@ -93,7 +93,7 @@ class ServerCompleteAuthorizeResponseTest extends TestCase
 
     public function testError()
     {
-        $response = m::mock('\Omnipay\SagePay\Message\ServerCompleteAuthorizeResponse')->makePartial();
+        $response = m::mock('\Omnipay\Opayo\Message\ServerCompleteAuthorizeResponse')->makePartial();
         $response->shouldReceive('sendResponse')->once()->with('ERROR', 'https://www.example.com/', 'detail');
 
         $response->error('https://www.example.com/', 'detail');
@@ -101,7 +101,7 @@ class ServerCompleteAuthorizeResponseTest extends TestCase
 
     public function testInvalid()
     {
-        $response = m::mock('\Omnipay\SagePay\Message\ServerCompleteAuthorizeResponse')->makePartial();
+        $response = m::mock('\Omnipay\Opayo\Message\ServerCompleteAuthorizeResponse')->makePartial();
         $response->shouldReceive('sendResponse')->once()->with('INVALID', 'https://www.example.com/', 'detail');
 
         $response->invalid('https://www.example.com/', 'detail');
@@ -109,7 +109,7 @@ class ServerCompleteAuthorizeResponseTest extends TestCase
 
     public function testSendResponse()
     {
-        $response = m::mock('\Omnipay\SagePay\Message\ServerCompleteAuthorizeResponse')->makePartial();
+        $response = m::mock('\Omnipay\Opayo\Message\ServerCompleteAuthorizeResponse')->makePartial();
         $response->shouldReceive('exitWith')->once()->with("Status=FOO\r\nRedirectUrl=https://www.example.com/");
 
         $response->sendResponse('FOO', 'https://www.example.com/');
@@ -117,7 +117,7 @@ class ServerCompleteAuthorizeResponseTest extends TestCase
 
     public function testSendResponseDetail()
     {
-        $response = m::mock('\Omnipay\SagePay\Message\ServerCompleteAuthorizeResponse')->makePartial();
+        $response = m::mock('\Omnipay\Opayo\Message\ServerCompleteAuthorizeResponse')->makePartial();
         $response->shouldReceive('exitWith')->once()->with("Status=FOO\r\nRedirectUrl=https://www.example.com/\r\nStatusDetail=Bar");
 
         $response->sendResponse('FOO', 'https://www.example.com/', 'Bar');

--- a/tests/Message/ServerNotifyRequestTest.php
+++ b/tests/Message/ServerNotifyRequestTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Omnipay\SagePay\Message;
+namespace Omnipay\Opayo\Message;
 
 use Omnipay\Tests\TestCase;
 use Mockery as m;

--- a/tests/Message/ServerPurchaseRequestTest.php
+++ b/tests/Message/ServerPurchaseRequestTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Omnipay\SagePay\Message;
+namespace Omnipay\Opayo\Message;
 
 use Omnipay\Tests\TestCase;
 

--- a/tests/Message/ServerTokenRegistrationRequestTest.php
+++ b/tests/Message/ServerTokenRegistrationRequestTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Omnipay\SagePay\Message;
+namespace Omnipay\Opayo\Message;
 
 use Omnipay\Tests\TestCase;
 use Mockery as m;

--- a/tests/Message/ServerTokenRegistrationResponseTest.php
+++ b/tests/Message/ServerTokenRegistrationResponseTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Omnipay\SagePay\Message;
+namespace Omnipay\Opayo\Message;
 
 use Omnipay\Tests\TestCase;
 

--- a/tests/Message/SharedAbortRequestTest.php
+++ b/tests/Message/SharedAbortRequestTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Omnipay\SagePay\Message;
+namespace Omnipay\Opayo\Message;
 
 use Omnipay\Tests\TestCase;
 

--- a/tests/Message/SharedCaptureRequestTest.php
+++ b/tests/Message/SharedCaptureRequestTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Omnipay\SagePay\Message;
+namespace Omnipay\Opayo\Message;
 
 use Omnipay\Tests\TestCase;
 

--- a/tests/Message/SharedRefundRequestTest.php
+++ b/tests/Message/SharedRefundRequestTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Omnipay\SagePay\Message;
+namespace Omnipay\Opayo\Message;
 
 use Omnipay\Tests\TestCase;
 

--- a/tests/Message/SharedRepeatAuthorizeRequestTest.php
+++ b/tests/Message/SharedRepeatAuthorizeRequestTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Omnipay\SagePay\Message;
+namespace Omnipay\Opayo\Message;
 
 use Omnipay\Tests\TestCase;
 
 class SharedRepeatAuthorizeRequestTest extends TestCase
 {
     /**
-     * @var \Omnipay\SagePay\Message\DirectRepeatAuthorizeRequest $request
+     * @var \Omnipay\Opayo\Message\DirectRepeatAuthorizeRequest $request
      */
     protected $request;
 

--- a/tests/Message/SharedRepeatPurchaseRequestTest.php
+++ b/tests/Message/SharedRepeatPurchaseRequestTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Omnipay\SagePay\Message;
+namespace Omnipay\Opayo\Message;
 
 use Omnipay\Tests\TestCase;
 
 class SharedRepeatPurchaseRequestTest extends TestCase
 {
     /**
-     * @var \Omnipay\SagePay\Message\DirectRepeatPurchaseRequest $request
+     * @var \Omnipay\Opayo\Message\DirectRepeatPurchaseRequest $request
      */
     protected $request;
 

--- a/tests/Message/SharedTokenRemovalRequestTest.php
+++ b/tests/Message/SharedTokenRemovalRequestTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Omnipay\SagePay\Message;
+namespace Omnipay\Opayo\Message;
 
 use Omnipay\Tests\TestCase;
 

--- a/tests/Message/SharedVoidRequestTest.php
+++ b/tests/Message/SharedVoidRequestTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Omnipay\SagePay\Message;
+namespace Omnipay\Opayo\Message;
 
 use Omnipay\Tests\TestCase;
 

--- a/tests/ServerGatewayTest.php
+++ b/tests/ServerGatewayTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Omnipay\SagePay;
+namespace Omnipay\Opayo;
 
 use Omnipay\Tests\GatewayTestCase;
 
@@ -63,7 +63,7 @@ class ServerGatewayTest extends GatewayTestCase
 
     public function testInheritsDirectGateway()
     {
-        $this->assertInstanceOf('Omnipay\SagePay\DirectGateway', $this->gateway);
+        $this->assertInstanceOf('Omnipay\Opayo\DirectGateway', $this->gateway);
     }
 
     public function testAuthorizeSuccess()


### PR DESCRIPTION
The Sage Pay product was renamed to Opayo in 2020. This commit brings
this package up to date.

According to the Opayo docs, the URLs for the actual APIs have not yet
changed so these have not been updated here either.