### PR TITLE
Fix data for ServerRestPurchaseRequest

### DIFF
--- a/src/ConstantsInterface.php
+++ b/src/ConstantsInterface.php
@@ -57,6 +57,33 @@ interface ConstantsInterface
     const APPLY_AVSCV2_NO_RULES     = 3;
 
     /**
+     * Supported 3D Secure settings for a RESTful payments integration, used to override default account-level settings.
+     *
+     * - UseMSPSetting - Use default MySagePay settings.
+     * - Force - Apply authentication even if turned off.
+     * - ForceIgnoringRules - Apply authentication but ignore rules.
+     * - Disable - Only use this if you intend to use an SCA Exemption
+     *   (https://developer-eu.elavon.com/docs/opayo/3d-secure-authentication/sca-exemptions)
+     */
+    const REST_APPLY_3DSECURE_DEFAULT = 'UseMSPSetting';
+    const REST_APPLY_3DSECURE_FORCE = 'Force';
+    const REST_APPLY_3DSECURE_FORCE_IGNORING_RULES = 'ForceIgnoringRules';
+    const REST_APPLY_3DSECURE_DISABLE = 'Disable';
+
+    /**
+     * Supported AVS CVS settings for a RESTful payments integration, used to overide default account-level settings
+     *
+     * - UseMSPSetting - Use defailt MySagePay settings.
+     * - Force - Apply authentication even if turned off.
+     * - ForceIgnoringRules - Apply authentication but ignore rules.
+     * - Disable - Disable authentication and rules
+     */
+    const REST_APPLY_AVS_CVC_CHECK_DEFAULT = 'UseMSPSetting';
+    const REST_APPLY_AVS_CVC_CHECK_FORCE = 'Force';
+    const REST_APPLY_AVS_CVC_CHECK_FORCE_IGNORING_RULES = 'ForceIgnoringRules';
+    const REST_APPLY_AVS_CVC_CHECK_DISABLE = 'Disable';
+
+    /**
      * Flag whether to store a cardReference or token for multiple use.
      */
     const STORE_TOKEN_YES   = 1;

--- a/src/Message/AbstractRestRequest.php
+++ b/src/Message/AbstractRestRequest.php
@@ -260,24 +260,33 @@ abstract class AbstractRestRequest extends AbstractRequest implements ConstantsI
     {
         $card = $this->getCard();
 
-        if (is_null($card->getShippingAddress1())) {
-            // If we don't have the required first line, assume no shipping address has been set.
+        $shippingDetails = [
+            'shippingAddress1' => $card->getShippingAddress1(),
+            'shippingAddress2' => $card->getShippingAddress2(),
+            'shippingCity' => $card->getShippingCity(),
+            'shippingPostalCode' => $card->getShippingPostcode(),
+            'shippingState' => $card->getShippingState(),
+            'shippingCountry' => $card->getShippingCountry(),
+        ];
+
+        $shippingDetails = array_filter($shippingDetails, function ($value) {
+            return ! is_null($value);
+        });
+
+        if (empty($shippingDetails)) {
+            // No shipping address components have been supplied, so don't add it to the data.
             // Opayo will default to using the billing address.
             return $data;
         }
 
-        $data['shippingDetails']['recipientFirstName'] = $card->getShippingFirstName();
-        $data['shippingDetails']['recipientLastName'] = $card->getShippingLastName();
-        $data['shippingDetails']['shippingAddress1'] = $card->getShippingAddress1();
-        $data['shippingDetails']['shippingAddress2'] = $card->getShippingAddress2();
-        $data['shippingDetails']['shippingCity'] = $card->getShippingCity();
-        $data['shippingDetails']['shippingPostalCode'] = $card->getShippingPostcode();
-        $data['shippingDetails']['shippingState'] = $card->getShippingState();
-        $data['shippingDetails']['shippingCountry'] = $card->getShippingCountry();
+        $data['shippingDetails'] = $shippingDetails;
 
         if ($data['shippingDetails']['shippingCountry'] !== 'US') {
             $data['shippingDetails']['shippingState'] = '';
         }
+
+        $data['shippingDetails']['recipientFirstName'] = $card->getShippingFirstName();
+        $data['shippingDetails']['recipientLastName'] = $card->getShippingLastName();
 
         return $data;
     }

--- a/src/Message/ServerRestPurchaseRequest.php
+++ b/src/Message/ServerRestPurchaseRequest.php
@@ -64,9 +64,9 @@ class ServerRestPurchaseRequest extends AbstractRestRequest
             $data['customerEmail'] = $card->getEmail();
         }
 
-        // $data['ApplyAVSCV2'] = $this->getApplyAVSCV2() ?: static::APPLY_AVSCV2_DEFAULT;
-        $data['apply3DSecure'] = $this->getApply3DSecure() ?: static::APPLY_3DSECURE_APPLY;
-        // user parent data here and the abstract can provide txtype vendor etc
+        $data['applyAvsCvcCheck'] = $this->getApplyAvsCvcCheck() ?? static::REST_APPLY_AVS_CVC_CHECK_DEFAULT;
+        $data['apply3DSecure'] = $this->getApply3DSecure() ?? static::REST_APPLY_3DSECURE_DEFAULT;
+
         return $data;
     }
 
@@ -87,10 +87,10 @@ class ServerRestPurchaseRequest extends AbstractRestRequest
     {
         $data['paymentMethod']['card']['merchantSessionKey'] = $this->getMerchantSessionKey();
         $data['paymentMethod']['card']['cardIdentifier'] = $this->getCardIdentifier();
-        if (!is_null($this->getTokenReusable())) {
+        if (! is_null($this->getTokenReusable())) {
             $data['paymentMethod']['card']['reusable'] = $this->getTokenReusable();
         }
-        if (!is_null($this->getTokenSave())) {
+        if (! is_null($this->getTokenSave())) {
             $data['paymentMethod']['card']['save'] = $this->getTokenSave();
         }
         return $data;

--- a/src/Traits/GatewayParamsTrait.php
+++ b/src/Traits/GatewayParamsTrait.php
@@ -115,7 +115,7 @@ trait GatewayParamsTrait
     }
 
     /**
-     * @return int|null One of APPLY_3DSECURE_*
+     * @return int|string|null One of APPLY_3DSECURE_* or REST_APPLY_3DSECURE_*
      */
     public function getApply3DSecure()
     {
@@ -126,16 +126,35 @@ trait GatewayParamsTrait
      * Whether or not to apply 3D secure authentication.
      *
      * This is ignored for PAYPAL, EUROPEAN PAYMENT transactions.
-     * Values defined in APPLY_3DSECURE_* constant.
+     * Values defined in APPLY_3DSECURE_* or REST_APPLY_3DSECURE_* constants. Only one set will be used depending on the
+     * integration required.
      *
-     * For values see constants APPLY_3DSECURE_*
-     *
-     * @param int $value 0-3
+     * @param int|string $value see constants for possible values
      * @return $this
      */
     public function setApply3DSecure($value)
     {
         return $this->setParameter('apply3DSecure', $value);
+    }
+
+    /**
+     * @return string|null One of REST_APPLY_AVS_CVC_CHECK_*
+     */
+    public function getApplyAvsCvcCheck()
+    {
+        return $this->getParameter('applyAvsCvcCheck');
+    }
+
+    /**
+     * Set whether or not to apply AVS CVC checks.
+     *
+     * Values defined in REST_APPLY_AVS_CVC_CHECK_* constants.
+     *
+     * @param string $value see constants for possible values
+     */
+    public function setApplyAvcCvcCheck($value)
+    {
+        return $this->setParameter('applyAvsCvcCheck', $value);
     }
 
     /**


### PR DESCRIPTION
- Use appropriate constants for 3DS and AVS CVC settings - the RESTful
  PI uses different keys and values to the other integrations.
- Make shipping details optional.
- Filter out null values rather than setting them to empty strings.