### PR TITLE
Add constants for REST/PI 3D secure statuses

### DIFF
--- a/src/ConstantsInterface.php
+++ b/src/ConstantsInterface.php
@@ -243,6 +243,35 @@ interface ConstantsInterface
     const SECURE3D_STATUS_INVALID       = 'INVALID';
 
     /**
+     * Possible 3DSecure statuses for a RESTful payment integration
+     *
+     * - Ok - Transaction request completed successfully
+     * - Authenticated - 3-D Secure checks carried out and user authenticated correctly.
+     * - NotChecked - 3-D Secure checks were not performed. This indicates that 3-D Secure was either switched off at
+     *   the account level, or disabled at transaction registration with the apply3DSecure set to Disable.
+     * - NotAuthenticated - 3-D Secure authentication checked, but the user failed the authentication.
+     * - Error - Authentication could not be attempted due to data errors or service unavailability in one of the
+     *   parties involved in the check.
+     * - CardNotEnrolled - This means that the card is not in the 3-D Secure scheme.
+     * - IssuerNotEnrolled - This means that the issuer is not part of the 3-D Secure scheme.
+     * - MalformedOrInvalid - This means that there is a problem with creating or receiving the 3D Secure data. These
+     *   should not occur on the live environment.
+     * - AttemptOnly - This means that the cardholder attempted to authenticate themselves but the process did not
+     *   complete. A liability shift may occur for non-Maestro cards, depending on your merchant agreement.
+     * - Incomplete - This means that the 3D Secure authentication was not available (normally at the card issuer site).
+     */
+    const REST_3DSECURE_STATUS_OK                   = 'Ok';
+    const REST_3DSECURE_STATUS_AUTHENTICATED        = 'Authenticated';
+    const REST_3DSECURE_STATUS_NOT_CHECKED          = 'NotChecked';
+    const REST_3DSECURE_STATUS_NOT_AUTHENTICATED    = 'NotAuthenticated';
+    const REST_3DSECURE_STATUS_ERROR                = 'Error';
+    const REST_3DSECURE_STATUS_CARD_NOT_ENROLLED    = 'CardNotEnrolled';
+    const REST_3DSECURE_STATUS_ISSUER_NOT_ENROLLED  = 'IssuerNotEnrolled';
+    const REST_3DSECURE_STATUS_MALFORMED_OR_INVALID = 'MalformedOrInvalid';
+    const REST_3DSECURE_STATUS_ATTEMPT_ONLY         = 'AttemptOnly';
+    const REST_3DSECURE_STATUS_INCOMPLETE           = 'Incomplete';
+
+    /**
      * Raw results for AddressStatus (PayPal only)
      * @var string
      */

--- a/src/Message/ServerRestCompleteResponse.php
+++ b/src/Message/ServerRestCompleteResponse.php
@@ -9,10 +9,11 @@ class ServerRestCompleteResponse extends RestResponse
 {
     /**
      *
-     * @return bool false
+     * @return bool
      */
     public function isSuccessful()
     {
-        return strtoupper($this->get3DSecureStatus() ?? $this->getStatus()) === static::OPAYO_STATUS_AUTHENTICATED;
+        return $this->get3DSecureStatus() === static::REST_3DSECURE_STATUS_AUTHENTICATED
+            || $this->getStatus() === static::OPAYO_STATUS_AUTHENTICATED;
     }
 }

--- a/src/Traits/ResponseRestFieldsTrait.php
+++ b/src/Traits/ResponseRestFieldsTrait.php
@@ -199,17 +199,17 @@ trait ResponseRestFieldsTrait
      * This field details the results of the 3D-Secure checks
      * where appropriate.
      *
-     * @return string One of static::SECURE3D_STATUS_*
+     * @return string|null One of static::REST_3DSECURE_STATUS_*
      */
     public function get3DSecureStatus()
     {
         $secure3DResponse = $this->getDataItem('3DSecure');
 
         if (is_array($secure3DResponse) && array_key_exists('status', $secure3DResponse)) {
-            return strtoupper($secure3DResponse['status']);
+            return $secure3DResponse['status'];
         }
 
-        return $secure3DResponse;
+        return null;
     }
 
     /**


### PR DESCRIPTION
The RESTful Payment Integration (Pi) uses a different set of 3DS
statuses from the other integrations.