### PR TITLE
Fix PI instruction requests

### DIFF
--- a/src/ConstantsInterface.php
+++ b/src/ConstantsInterface.php
@@ -135,6 +135,13 @@ interface ConstantsInterface
     const TXTYPE_REPEATDEFERRED = 'REPEATDEFERRED';
 
     /**
+     * Instruction types for PI transaction instructions
+     */
+    const INSTRUCTION_TYPE_ABORT   = 'abort';
+    const INSTRUCTION_TYPE_RELEASE = 'release';
+    const INSTRUCTION_TYPE_VOID    = 'void';
+
+    /**
      *
      */
     const SERVICE_SERVER_REGISTER   = 'vspserver-register';

--- a/src/Message/ServerRestAbortRequest.php
+++ b/src/Message/ServerRestAbortRequest.php
@@ -15,14 +15,6 @@ class ServerRestAbortRequest extends AbstractRestRequest
     }
 
     /**
-     * @return string the transaction type
-     */
-    public function getTxType()
-    {
-        return ucfirst(strtolower(static::TXTYPE_ABORT));
-    }
-
-    /**
      * Instruction data.
      *
      * @return array
@@ -30,7 +22,7 @@ class ServerRestAbortRequest extends AbstractRestRequest
     public function getData()
     {
         return [
-            'instructionType ' => $this->getTxType(),
+            'instructionType' => static::INSTRUCTION_TYPE_ABORT,
         ];
     }
 

--- a/src/Message/ServerRestCaptureRequest.php
+++ b/src/Message/ServerRestCaptureRequest.php
@@ -15,14 +15,6 @@ class ServerRestCaptureRequest extends AbstractRestRequest
     }
 
     /**
-     * @return string the transaction type
-     */
-    public function getTxType()
-    {
-        return ucfirst(strtolower(static::TXTYPE_RELEASE));
-    }
-
-    /**
      * Instruction data.
      *
      * @return array
@@ -30,7 +22,7 @@ class ServerRestCaptureRequest extends AbstractRestRequest
     public function getData()
     {
         return [
-            'instructionType ' => $this->getTxType(),
+            'instructionType' => static::INSTRUCTION_TYPE_RELEASE,
             'amount' => $this->getAmountInteger(),
         ];
     }

--- a/src/Message/ServerRestVoidRequest.php
+++ b/src/Message/ServerRestVoidRequest.php
@@ -3,7 +3,6 @@
 namespace Omnipay\Opayo\Message;
 
 use Omnipay\Opayo\Message\ServerRestInstructionResponse;
-use Omnipay\Opayo\Message\ServerRestRefundResponse;
 
 /**
  * Opayo REST Server Refund Request
@@ -21,24 +20,15 @@ class ServerRestVoidRequest extends AbstractRestRequest
     }
 
     /**
-     * @return string the transaction type
-     */
-    public function getTxType()
-    {
-        return ucfirst(strtolower(static::TXTYPE_VOID));
-    }
-
-    /**
      * Instruction data.
      *
      * @return array
      */
     public function getData()
     {
-        $data = $this->getBaseData();
-
-        $data['instructionType'] = $this->getTxType();
-        return $data;
+        return [
+            'instructionType' => static::INSTRUCTION_TYPE_VOID,
+        ];
     }
 
     public function getParentServiceReference()


### PR DESCRIPTION
These requests do not need a transaction type, only an instruction type,
which should be lowercase.